### PR TITLE
Pull docker services before up

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ install:
 start_services:
 	git clone --depth 1 ${RAS_RM_REPO_URL} tmp_ras_rm_docker_dev
 	cd tmp_ras_rm_docker_dev\
-	&& make up
+	&& make pull && make up
 	pipenv run python wait_until_services_up.py
 
 stop_services:


### PR DESCRIPTION
When running locally, we want to make sure that the services that are brought in by the Make start_services / test commands are using the latest versions.