### PR TITLE
Add tests for adding eq ci

### DIFF
--- a/acceptance_tests/features/pages/collection_exercise_details.py
+++ b/acceptance_tests/features/pages/collection_exercise_details.py
@@ -84,12 +84,21 @@ def select_wrong_file_type(test_file):
     browser.driver.find_element_by_id('ciFile').send_keys(abspath(test_file))
 
 
+def add_eq_ci():
+    browser.find_by_name('checkbox-answer').check()
+    browser.find_by_id('btn-add-ci').click()
+
+
 def get_collection_instrument_error_text():
     return browser.driver.find_element_by_id('ciFileErrorText').text
 
 
 def get_collection_instrument_success_text():
     return browser.find_by_id('collection-instrument-success').text
+
+
+def get_collection_instrument_added_success_text():
+    return browser.find_by_id('collection-instrument-added-success').text
 
 
 def get_collection_instruments():

--- a/acceptance_tests/features/select_eq_collection_instrument.feature
+++ b/acceptance_tests/features/select_eq_collection_instrument.feature
@@ -1,0 +1,13 @@
+Feature: Select EQ Collection Instruments
+  As a Collection Exercise Coordinator
+  I need to be able to select the eQ collection instruments in the system for a given collection exercise
+  and given survey
+  So that the collection instrument can be associated with the RU's in the sample within the CE
+
+  Background: Internal user is already signed in
+    Given the internal user is already signed in
+
+  Scenario: The user is able to select the EQ collection instruments to load into the collection exercise
+    Given the internal user navigates to the collection exercise details page for QBS 1803
+    When the user selects the collection instrument
+    Then the collection instrument is added into the collection exercise

--- a/acceptance_tests/features/select_eq_collection_instrument.feature
+++ b/acceptance_tests/features/select_eq_collection_instrument.feature
@@ -7,6 +7,7 @@ Feature: Select eQ Collection Instruments
   Background: Internal user is already signed in
     Given the internal user is already signed in
 
+  @us029-selectEqCI_s01
   Scenario: The user is able to select the eQ collection instruments to load into the collection exercise
     Given the internal user navigates to the collection exercise details page for QBS 1803
     When the user selects the collection instrument

--- a/acceptance_tests/features/select_eq_collection_instrument.feature
+++ b/acceptance_tests/features/select_eq_collection_instrument.feature
@@ -1,4 +1,4 @@
-Feature: Select EQ Collection Instruments
+Feature: Select eQ Collection Instruments
   As a Collection Exercise Coordinator
   I need to be able to select the eQ collection instruments in the system for a given collection exercise
   and given survey
@@ -7,7 +7,7 @@ Feature: Select EQ Collection Instruments
   Background: Internal user is already signed in
     Given the internal user is already signed in
 
-  Scenario: The user is able to select the EQ collection instruments to load into the collection exercise
+  Scenario: The user is able to select the eQ collection instruments to load into the collection exercise
     Given the internal user navigates to the collection exercise details page for QBS 1803
     When the user selects the collection instrument
     Then the collection instrument is added into the collection exercise

--- a/acceptance_tests/features/steps/select_eq_collection_instruments.py
+++ b/acceptance_tests/features/steps/select_eq_collection_instruments.py
@@ -1,0 +1,14 @@
+from behave import when, then
+
+from acceptance_tests.features.pages import collection_exercise_details
+
+
+@when('the user selects the collection instrument')
+def select_eq_ci(_):
+    collection_exercise_details.add_eq_ci()
+
+
+@then('the collection instrument is added into the collection exercise')
+def eq_ci_linked_to_ce(_):
+    success_text = collection_exercise_details.get_collection_instrument_added_success_text()
+    assert success_text == 'Collection instruments added'

--- a/controllers/collection_instrument_controller.py
+++ b/controllers/collection_instrument_controller.py
@@ -1,3 +1,4 @@
+import json
 import logging
 
 import requests
@@ -9,8 +10,8 @@ from config import Config
 logger = wrap_logger(logging.getLogger(__name__))
 
 
-def upload_collection_instrument(collection_exercise_id, file_path):
-    logger.info('Uploading collection instrument', collection_exercise_id=collection_exercise_id)
+def upload_seft_collection_instrument(collection_exercise_id, file_path):
+    logger.info('Uploading SEFT collection instrument', collection_exercise_id=collection_exercise_id)
     url = f'{Config.COLLECTION_INSTRUMENT_SERVICE}/' \
           f'collection-instrument-api/1.0.2/upload/{collection_exercise_id}'
     mimetype = 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
@@ -18,3 +19,22 @@ def upload_collection_instrument(collection_exercise_id, file_path):
     response = requests.post(url=url, auth=Config.BASIC_AUTH, files=files)
     response.raise_for_status()
     logger.info('Successfully uploaded collection instrument', collection_exercise_id=collection_exercise_id)
+
+
+def upload_eq_collection_instrument(survey_id, form_type, eq_id):
+    logger.info('Uploading eQ collection instrument', survey_id=survey_id, form_type=form_type)
+    url = f'{Config.COLLECTION_INSTRUMENT_SERVICE}/' \
+          f'collection-instrument-api/1.0.2/upload'
+
+    classifiers = {
+        "FORM_TYPE": form_type,
+        "EQ_ID": eq_id
+    }
+
+    params = {
+        "classifiers": json.dumps(classifiers),
+        "survey_id": survey_id
+    }
+    response = requests.post(url=url, auth=Config.BASIC_AUTH, params=params)
+    response.raise_for_status()
+    logger.info('Successfully uploaded eQ collection instrument', survey_id=survey_id, form_type=form_type)

--- a/controllers/collection_instrument_controller.py
+++ b/controllers/collection_instrument_controller.py
@@ -27,8 +27,8 @@ def upload_eq_collection_instrument(survey_id, form_type, eq_id):
           f'collection-instrument-api/1.0.2/upload'
 
     classifiers = {
-        "FORM_TYPE": form_type,
-        "EQ_ID": eq_id
+        "form_type": form_type,
+        "eq_id": eq_id
     }
 
     params = {

--- a/set_up_ce_execution.py
+++ b/set_up_ce_execution.py
@@ -12,6 +12,11 @@ if __name__ == '__main__':
     bricks_201812_ce = collection_exercise_controller.get_collection_exercise('cb8accda-6118-4d3b-85a3-149e28960c54',
                                                                               '201812')
     ci_path = 'resources/collection_instrument_files/064_0001_201803.xlsx'
-    collection_instrument_controller.upload_collection_instrument(bricks_201801_ce['id'], ci_path)
-    collection_instrument_controller.upload_collection_instrument(bricks_201812_ce['id'], ci_path)
+    collection_instrument_controller.upload_seft_collection_instrument(bricks_201801_ce['id'], ci_path)
+    collection_instrument_controller.upload_seft_collection_instrument(bricks_201812_ce['id'], ci_path)
+
+    # upload eQ collection instrument for QBS
+    collection_instrument_controller.upload_eq_collection_instrument('02b9c366-7397-42f7-942a-76dc5876d86d',
+                                                                     '0001', '2')
+
     print("Required collection exercises can be executed")


### PR DESCRIPTION
Scenario: The user is able to select the EQ collection instruments to load into the collection exercise
    Given the internal user navigates to the collection exercise details page for QBS 1803
    When the user selects the collection instrument
    Then the collection instrument is added into the collection exercise

Dependencies:
https://github.com/ONSdigital/ras-collection-instrument/pull/100