### PR TITLE
Define test steps only in make file to avoid issues with duplication

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ install:
 
 script:
   - pipenv check --style . --max-line-length 120
-  - make start_services setup acceptance_tests stop_services
+  - make test
 
 branches:
   only:


### PR DESCRIPTION
[Makefile line](https://github.com/ONSdigital/rasrm-acceptance-tests/blob/master/Makefile#L42) it was duplicating.