### PR TITLE
US047 Add tests for viewing Live state of a collection exercise

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ install:
 start_services:
 	if [ -d tmp_ras_rm_docker_dev ]; then \
 		echo "tmp_ras_rm_docker_dev exists - pulling"; \
-		cd tmp_rm_tools; git pull; cd -; \
+		cd tmp_ras_rm_docker_dev; git pull; cd -; \
 	else \
 		git clone --depth 1 ${RAS_RM_REPO_URL} tmp_ras_rm_docker_dev; \
 	fi; \

--- a/acceptance_tests/features/pages/collection_exercise.py
+++ b/acceptance_tests/features/pages/collection_exercise.py
@@ -65,6 +65,6 @@ def get_table_row_by_period(period):
             return row
 
 
-def click_qbs_1803_ce_link():
-    link = browser.find_by_name('ce-link-1803')
+def click_ce_link(period):
+    link = browser.find_by_name(f'ce-link-{period}')
     link.click()

--- a/acceptance_tests/features/steps/site_navigation.py
+++ b/acceptance_tests/features/steps/site_navigation.py
@@ -22,5 +22,5 @@ def should_be_able_to_click_qbs_survey_link(_):
 
 @then('the user can view and click on a link to the 1803 QBS collection exercise page')
 def should_be_able_to_click_qbs_collection_exercise_link(_):
-    collection_exercise.click_qbs_1803_ce_link()
+    collection_exercise.click_ce_link('1803')
     assert collection_exercise_details.get_page_title() == '139 QBS 1803 | Surveys | Survey Data Collection'

--- a/acceptance_tests/features/steps/view_collection_exercise_live_state.py
+++ b/acceptance_tests/features/steps/view_collection_exercise_live_state.py
@@ -3,7 +3,7 @@ import time
 from behave import given, when, then
 
 from acceptance_tests import browser
-from acceptance_tests.features.pages import collection_exercise, collection_exercise_details, survey
+from acceptance_tests.features.pages import collection_exercise, collection_exercise_details
 from controllers import collection_exercise_controller
 
 

--- a/acceptance_tests/features/steps/view_collection_exercise_live_state.py
+++ b/acceptance_tests/features/steps/view_collection_exercise_live_state.py
@@ -45,7 +45,7 @@ def ce_details_state_is_live(_):
     assert collection_exercise.is_live(ce_state), ce_state
 
 
-@then('they are able to see the Status for "{period}"')
+@then('they are able to see the Live Status for "{period}"')
 def survey_ce_state_is_live(_, period):
     ce_state = collection_exercise.get_table_row_by_period(period)['state']
     assert collection_exercise.is_live(ce_state), ce_state

--- a/acceptance_tests/features/steps/view_collection_exercise_live_state.py
+++ b/acceptance_tests/features/steps/view_collection_exercise_live_state.py
@@ -1,0 +1,51 @@
+import time
+
+from behave import given, when, then
+
+from acceptance_tests import browser
+from acceptance_tests.features.pages import collection_exercise, collection_exercise_details, survey
+from controllers import collection_exercise_controller
+
+
+@given('the user has confirmed that "{survey}" "{period}" is Ready for Live')
+def internal_user_views_ready_for_live(_, survey, period):
+    collection_exercise_details.go_to(survey, period)
+    ce_state = collection_exercise_details.get_status()
+    assert collection_exercise.is_ready_for_live(ce_state), ce_state
+
+
+@given('the user is on the "{survey}" Page')
+@when('they navigate to the "{survey}" page')
+def user_navigate_to_survey_details(_, survey):
+    collection_exercise.go_to(survey)
+
+
+@when('they navigate to the Collection Exercise Details Page for "{period}"')
+def user_navigate_to_ce_details(_, period):
+    collection_exercise.click_ce_link(period)
+
+
+@when('"{survey}" "{period}" go live date hits')
+def go_live_date_hits(_, survey, period):
+    # PUT to force the scheduler
+    s_id = {
+        'rsi': '75b19ea0-69a4-4c58-8d7f-4458c8f43f5c',
+        'bricks': 'cb8accda-6118-4d3b-85a3-149e28960c54',
+    }[survey.lower()]
+    datetime = '2018-01-21T00:00:00.000Z'  # some time in the past
+    collection_exercise_controller.update_event_for_collection_exercise(s_id, period, 'go_live', datetime)
+    time.sleep(1)
+    browser.reload()
+
+
+@then('the state of a collection exercise is to be changed to Live')
+@then('they are able to see the Live Status for that Collection Exercise')
+def ce_details_state_is_live(_):
+    ce_state = collection_exercise_details.get_status()
+    assert collection_exercise.is_live(ce_state), ce_state
+
+
+@then('they are able to see the Status for "{period}"')
+def survey_ce_state_is_live(_, period):
+    ce_state = collection_exercise.get_table_row_by_period(period)['state']
+    assert collection_exercise.is_live(ce_state), ce_state

--- a/acceptance_tests/features/steps/view_collection_exercise_live_state.py
+++ b/acceptance_tests/features/steps/view_collection_exercise_live_state.py
@@ -34,14 +34,18 @@ def go_live_date_hits(_, survey, period):
     }[survey.lower()]
     datetime = '2018-01-21T00:00:00.000Z'  # some time in the past
     collection_exercise_controller.update_event_for_collection_exercise(s_id, period, 'go_live', datetime)
-    time.sleep(1)
-    browser.reload()
 
 
 @then('the state of a collection exercise is to be changed to Live')
 @then('they are able to see the Live Status for that Collection Exercise')
 def ce_details_state_is_live(_):
     ce_state = collection_exercise_details.get_status()
+    for i in range(5):
+        if collection_exercise.is_live(ce_state):
+            break
+        time.sleep(1)
+        browser.reload()
+        ce_state = collection_exercise_details.get_status()
     assert collection_exercise.is_live(ce_state), ce_state
 
 

--- a/acceptance_tests/features/view_collection_exercise_live_state.feature
+++ b/acceptance_tests/features/view_collection_exercise_live_state.feature
@@ -1,0 +1,25 @@
+Feature: View live state of a collection exercise
+  As a Collection Exercise Coordinator
+  I need to be able to view the state of a collection exercise when it is Live
+  So that I know which collection exercises have gone live
+
+  Background: Internal user is already signed in
+    Given the internal user is already signed in
+
+  @us047_s001
+  Scenario: The 'Live' state is to be displayed when the collection exercise goes live (the 'go live' date hits) and collection instrument is available to respondent
+    Given the user has confirmed that "bricks" "201801" is Ready for Live
+    When "bricks" "201801" go live date hits
+    Then the state of a collection exercise is to be changed to Live
+
+  @us047_s002
+  Scenario: The state can be viewed on the survey details page
+    Given the user is on the Survey Page
+    When they navigate to the "bricks" page
+    Then they are able to see the Status for "201801"
+
+  @us047_s003
+  Scenario: The state can be viewed on the collection exercise details page
+    Given the user is on the "bricks" Page
+    When they navigate to the Collection Exercise Details Page for "201801"
+    Then they are able to see the Live Status for that Collection Exercise

--- a/acceptance_tests/features/view_collection_exercise_live_state.feature
+++ b/acceptance_tests/features/view_collection_exercise_live_state.feature
@@ -16,7 +16,7 @@ Feature: View live state of a collection exercise
   Scenario: The state can be viewed on the survey details page
     Given the user is on the Survey Page
     When they navigate to the "bricks" page
-    Then they are able to see the Status for "201801"
+    Then they are able to see the Live Status for "201801"
 
   @us047_s003
   Scenario: The state can be viewed on the collection exercise details page

--- a/controllers/collection_exercise_controller.py
+++ b/controllers/collection_exercise_controller.py
@@ -78,6 +78,20 @@ def post_event_to_collection_exercise(survey_id, period, event_tag, date_str):
     logger.info('Event added')
 
 
+def update_event_for_collection_exercise(survey_id, period, event_tag, date_str):
+    collection_exercise_id = get_collection_exercise(survey_id, period)['id']
+    logger.info('Updating an event', collection_exercise_id=collection_exercise_id, event_tag=event_tag)
+
+    url = f'{Config.COLLECTION_EXERCISE}/collectionexercises/{collection_exercise_id}/events/{event_tag}'
+    response = requests.put(url, auth=Config.BASIC_AUTH, data=date_str, headers={'content-type': 'text/plain'})
+    # 409: event already exists, which we count as permissable for testing
+    if response.status_code not in (201, 204, 409):
+        logger.error('Failed to post event', status=response.status_code)
+        raise Exception(f'Failed to update event {collection_exercise_id}')
+
+    logger.info('Event updated')
+
+
 def delete_collection_exercise_event(survey_id, period, event_tag):
     collection_exercise_id = get_collection_exercise(survey_id, period)['id']
     logger.info('Deleting an event', collection_exercise_id=collection_exercise_id, event_tag=event_tag)


### PR DESCRIPTION
CE's with go-live events in the past in reality should have already been flagged somehow. This botches things somewhat by forcing the scheduler's hand with an alteration (via PUT to /events) to a collection exercise's go-live event.

To test: 
```bash
pipenv install --dev && make start_services system_tests setup && pipenv run behave acceptance_tests/features/view_collection_exercise_live_state.feature
```