### PR TITLE
Assert correct associated respondent

### DIFF
--- a/acceptance_tests/features/steps/view_reporting_unit_details.py
+++ b/acceptance_tests/features/steps/view_reporting_unit_details.py
@@ -74,7 +74,7 @@ def internal_internal_user_presented_correct_associated_respondents(_):
         browser.reload()
         associated_respondents = reporting_unit.get_associated_respondents()
         time.sleep(1)
-    assert len(associated_respondents) == 2
+    assert len(associated_respondents) == 1
     assert associated_respondents[0]['enrolementStatus'] == 'Enabled'
     assert associated_respondents[0]['name'] == 'first_name last_name'
     assert associated_respondents[0]['email'] == 'example@example.com'


### PR DESCRIPTION
This ( https://github.com/ONSdigital/ras-backstage/pull/78 ) bug fix will break the acceptance test for scenario, Able to view respondent details for the RU Ref for the survey. Will need to merge this in after the bug fix is merged in.
