### PR TITLE
US058 update respondent email

### DIFF
--- a/acceptance_tests/features/edit_respondent_details.feature
+++ b/acceptance_tests/features/edit_respondent_details.feature
@@ -5,14 +5,12 @@ Feature: As an internal user
   Background: Internal user is already signed in
     Given the internal user is already signed in
 
-  @skip
   @us057-s01
   Scenario: The internal user is able to change a respondents first name, last name and contact number
     Given the internal user has found the respondents details
     When they choose to change the name of a respondent
     Then the respondent account details become editable
 
-  @skip
   @us057-s02
   Scenario: The internal user is able to enter up to 254 characters for the first and last name
     Given the internal user chooses to change the account details
@@ -20,7 +18,6 @@ Feature: As an internal user
     And they click save
     Then they are able to enter up to 254 characters
 
-  @skip
   @us057-s03
   Scenario: All fields are required to be populated
     Given the internal user chooses to change the account details
@@ -28,7 +25,6 @@ Feature: As an internal user
     And they click save
     Then the changes will not be saved and they are informed that all fields are required
 
-  @skip
   @us057-s04
   Scenario: The internal user is able to save any changes made to the account details
     Given the internal user chooses to change the account details
@@ -37,7 +33,6 @@ Feature: As an internal user
     Then they are navigated back to the RU Details page
     And they are provided with confirmation the changes have been saved
 
-  @skip
   @us057-s05
   Scenario: The internal user is able to cancel out of changing the respondent details at any point
     Given the internal user chooses to change the account details

--- a/acceptance_tests/features/edit_respondent_details.feature
+++ b/acceptance_tests/features/edit_respondent_details.feature
@@ -7,7 +7,7 @@ Feature: As an internal user
 
   @us057-s01
   Scenario: The internal user is able to change a respondents first name, last name and contact number
-    Given the internal user has found the respondents details for 49900000001
+    Given the internal user has found the respondents details
     When they choose to change the name of a respondent
     Then the respondent account details become editable
 
@@ -40,3 +40,49 @@ Feature: As an internal user
     And they decide to cancel
     Then they are navigated back to the RU Details page
     And the contact number is not changed
+
+  @us058-s001
+  Scenario: The user is able to edit the email address of a respondent
+    Given the respondent with email "test_respondent@test.com" is enrolled
+    And the internal user has found the respondents details
+    When they change the email address
+    And they click save
+    Then they are able to save the updated email address
+
+  @us058-s002
+  Scenario: The user is able to enter up to 254 characters for an email address
+    Given the respondent with email "test_respondent@test.com" is enrolled
+    And the user chooses to change a respondents email address
+    When they change the email address
+    And they click save
+    Then they are able to enter up to 254 characters
+
+  @us058-s003
+  Scenario: The user is able to to save any changes made to the email address
+    Given the respondent with email "test_respondent@test.com" is enrolled
+    And the internal user chooses to change the account details
+    When they change the email address
+    And they click save
+    Then they are provided with confirmation that the email address has been changed
+
+  @us058-s005
+  Scenario: The user is able to cancel out of changing the respondent details at any point
+    Given the internal user chooses to change the account details
+    When they change the email address
+    And they decide to cancel
+    Then they are navigated back to the RU Details page
+    And the email is not changed
+
+  @us058-s006
+  Scenario: The user is to be informed if the email address entered is already in use and is unable to save
+    Given the user chooses to change a respondents email address
+    When they save an email address that is already in use
+    Then they are informed that the email address they have entered is already in use
+
+  @us058-s007
+  Scenario: The user is to receive on-screen confirmation that the system has saved the changes
+    Given the respondent with email "test_respondent@test.com" is enrolled
+    And the user chooses to change a respondents email address
+    When they change the email address
+    And they click save
+    Then they are presented with confirmation that the changes have been saved

--- a/acceptance_tests/features/environment.py
+++ b/acceptance_tests/features/environment.py
@@ -29,7 +29,8 @@ def before_all(context):
         authentication.signed_in_internal(context)
         execute_collection_exercises()
         database_controller.execute_rm_sql('resources/database/rsi_populate_action_rules.sql')
-        register_respondent(survey_id='cb8accda-6118-4d3b-85a3-149e28960c54', period='201801')
+        register_respondent(survey_id='cb8accda-6118-4d3b-85a3-149e28960c54', period='201801',
+                            username=Config.RESPONDENT_USERNAME)
         sign_out_internal.sign_out()
     except WebDriverException:
         logger.exception('Failed to setup before running tests', html=browser.html)
@@ -82,10 +83,10 @@ def poll_database_for_iac(survey_id, period):
         time.sleep(5)
 
 
-def register_respondent(survey_id, period):
+def register_respondent(survey_id, period, username):
     collection_exercise_id = collection_exercise_controller.get_collection_exercise(survey_id, period)['id']
     enrolment_code = database_controller.get_iac_for_collection_exercise(collection_exercise_id)
-    respondent_party = party_controller.register_respondent(email_address=Config.RESPONDENT_USERNAME,
+    respondent_party = party_controller.register_respondent(email_address=username,
                                                             first_name='first_name',
                                                             last_name='last_name',
                                                             password=Config.RESPONDENT_PASSWORD,

--- a/acceptance_tests/features/pages/edit_respondent_details_form.py
+++ b/acceptance_tests/features/pages/edit_respondent_details_form.py
@@ -23,3 +23,7 @@ def click_save():
 
 def click_cancel():
     browser.find_by_id('cancel-btn').click()
+
+
+def edit_email_address(email):
+    browser.find_by_id('email').fill(email)

--- a/acceptance_tests/features/pages/reporting_unit.py
+++ b/acceptance_tests/features/pages/reporting_unit.py
@@ -77,9 +77,14 @@ def click_generate_new_code():
     browser.find_by_id('generate-new-code').click()
 
 
-def click_edit_details():
-    browser.find_by_id('edit-contact-details-btn').click()
+def click_edit_details(survey_short_name):
+    browser.execute_script("window.scrollTo(0, document.body.scrollHeight);")
+    browser.find_by_id(f'edit-contact-details-btn-{survey_short_name}').click()
 
 
-def confirm_contact_details_changes():
-    return browser.find_by_id('contact-changed')
+def get_confirm_contact_details_success_text():
+    return browser.find_by_id('success').text
+
+
+def save_email_error():
+    return browser.find_by_id('save-email-error')

--- a/acceptance_tests/features/pages/reporting_unit.py
+++ b/acceptance_tests/features/pages/reporting_unit.py
@@ -78,7 +78,6 @@ def click_generate_new_code():
 
 
 def click_edit_details(survey_short_name):
-    browser.execute_script("window.scrollTo(0, document.body.scrollHeight);")
     browser.find_by_id(f'edit-contact-details-btn-{survey_short_name}').click()
 
 

--- a/acceptance_tests/features/steps/edit_respondent_details.py
+++ b/acceptance_tests/features/steps/edit_respondent_details.py
@@ -1,27 +1,35 @@
 from behave import given, when, then
+
 from acceptance_tests import browser
-
+from acceptance_tests.features.environment import register_respondent
 from acceptance_tests.features.pages import edit_respondent_details_form, reporting_unit
+from config import Config
+from controllers.party_controller import get_party_by_ru_ref, get_respondent_details, get_party_by_email
 
 
-@given('the internal user has found the respondents details for 49900000001')
-def internal_user_find_respondent_details(_):
-    reporting_unit.go_to('49900000001')
-    reporting_unit.click_data_panel('Bricks')
+@given('the respondent with email "test_respondent@test.com" is enrolled')
+def respondent_email_is_enrolled(_):
+    business = get_party_by_ru_ref('49900000001')
+    respondent_id = business['associations'][0]['partyId']
+    respondent = get_respondent_details(respondent_id)
+    if respondent['emailAddress'] != 'test_respondent@test.com':
+        reporting_unit.go_to('49900000001')
+        reporting_unit.click_data_panel('Bricks')
+        reporting_unit.click_edit_details('Bricks')
+        edit_respondent_details_form.edit_email_address('test_respondent@test.com')
+        edit_respondent_details_form.click_save()
 
 
-@when('they choose to change the name of a respondent')
-def click_edit_details(_):
-    reporting_unit.click_edit_details()
-
-
+@given('the internal user has found the respondents details')
 @given('the internal user chooses to change the account details')
+@given('the user chooses to change a respondents email address')
 def open_edit_details(_):
     reporting_unit.go_to('49900000001')
     reporting_unit.click_data_panel('Bricks')
-    reporting_unit.click_edit_details()
+    reporting_unit.click_edit_details('Bricks')
 
 
+@when('they choose to change the name of a respondent')
 @when('they change the first and last name')
 def edit_first_last_name(_):
     edit_respondent_details_form.edit_first_name('Jacky')
@@ -36,6 +44,22 @@ def clear_old_contact_number(_):
 @when('they change the contact number')
 def change_contact_number(_):
     edit_respondent_details_form.edit_contact_number("01633 878787")
+
+
+@when('they change the email address')
+def edit_email_address(_):
+    edit_respondent_details_form.edit_email_address(Config.RESPONDENT_USERNAME)
+
+
+@when('they save an email address that is already in use')
+def save_email_already_in_use(_):
+    existing_email = 'existing_respondent@email.com'
+    email_found = get_party_by_email(existing_email)
+    if not email_found:
+        register_respondent(survey_id='cb8accda-6118-4d3b-85a3-149e28960c54', period='201801',
+                            username=existing_email)
+    edit_respondent_details_form.edit_email_address(existing_email)
+    edit_respondent_details_form.click_save()
 
 
 @then('the respondent account details become editable')
@@ -63,8 +87,16 @@ def navigate_to_ru_details(_):
 
 
 @then('they are provided with confirmation the changes have been saved')
+@then('they are able to save the updated email address')
 def confirm_changes_saved(_):
-    assert reporting_unit.confirm_contact_details_changes()
+    assert reporting_unit.get_confirm_contact_details_success_text()
+
+
+@then('they are provided with confirmation that the email address has been changed')
+@then('they are presented with confirmation that the changes have been saved')
+def confirm_email_changes_saved(_):
+    contact_details_changes = reporting_unit.get_confirm_contact_details_success_text()
+    assert 'Verification email sent to' in contact_details_changes
 
 
 @then('the contact number is not changed')
@@ -72,3 +104,15 @@ def confirm_contact_number_unchanged(_):
     reporting_unit.click_data_panel('Bricks')
     respondent = reporting_unit.get_associated_respondents()[0]
     assert respondent.get('phone') == '01633 878787'
+
+
+@then('the email is not changed')
+def confirm_email_unchanged(_):
+    reporting_unit.click_data_panel('Bricks')
+    respondent = reporting_unit.get_associated_respondents()[0]
+    assert respondent.get('email') == Config.RESPONDENT_USERNAME
+
+
+@then('they are informed that the email address they have entered is already in use')
+def error_email_already_in_use(_):
+    assert reporting_unit.save_email_error()

--- a/acceptance_tests/features/steps/edit_respondent_details.py
+++ b/acceptance_tests/features/steps/edit_respondent_details.py
@@ -53,12 +53,9 @@ def edit_email_address(_):
 
 @when('they save an email address that is already in use')
 def save_email_already_in_use(_):
-    existing_email = 'existing_respondent@email.com'
-    email_found = get_party_by_email(existing_email)
-    if not email_found:
-        register_respondent(survey_id='cb8accda-6118-4d3b-85a3-149e28960c54', period='201801',
-                            username=existing_email)
-    edit_respondent_details_form.edit_email_address(existing_email)
+    email = 'existing_respondent@email.com'
+    create_respondent(email)
+    edit_respondent_details_form.edit_email_address(email)
     edit_respondent_details_form.click_save()
 
 
@@ -116,3 +113,10 @@ def confirm_email_unchanged(_):
 @then('they are informed that the email address they have entered is already in use')
 def error_email_already_in_use(_):
     assert reporting_unit.save_email_error()
+
+
+def create_respondent(email):
+    email_in_use = get_party_by_email(email)
+    if not email_in_use:
+        register_respondent(survey_id='cb8accda-6118-4d3b-85a3-149e28960c54', period='201801',
+                            username=email)

--- a/acceptance_tests/features/steps/view_reporting_unit_details.py
+++ b/acceptance_tests/features/steps/view_reporting_unit_details.py
@@ -27,7 +27,7 @@ def respondent_first_name_is_enrolled(_):
             or respondent['telephone'] != "0987654321":
         reporting_unit.go_to('49900000001')
         reporting_unit.click_data_panel('Bricks')
-        reporting_unit.click_edit_details()
+        reporting_unit.click_edit_details('Bricks')
         edit_respondent_details_form.edit_first_name('first_name')
         edit_respondent_details_form.edit_last_name('last_name')
         edit_respondent_details_form.edit_contact_number('0987654321')

--- a/acceptance_tests/features/steps/view_reporting_unit_details.py
+++ b/acceptance_tests/features/steps/view_reporting_unit_details.py
@@ -24,7 +24,7 @@ def respondent_first_name_is_enrolled(_):
     respondent = get_respondent_details(respondent_id)
     if respondent['firstName'] != 'first_name' \
             or respondent['lastName'] != 'last_name' \
-            or respondent['phone'] != "0987654321":
+            or respondent['telephone'] != "0987654321":
         reporting_unit.go_to('49900000001')
         reporting_unit.click_data_panel('Bricks')
         reporting_unit.click_edit_details()

--- a/acceptance_tests/features/view_reporting_unit_details.feature
+++ b/acceptance_tests/features/view_reporting_unit_details.feature
@@ -26,7 +26,6 @@ Feature: View reporting unit details
     And the internal user opens the Bricks data panel
     Then the internal user is presented with the associated collection exercises
 
-  @skip
   @us046_s01
   Scenario: Able to view respondent details for the RU Ref for the survey
     Given the reporting unit 49900000001 is in the system

--- a/controllers/party_controller.py
+++ b/controllers/party_controller.py
@@ -63,3 +63,20 @@ def add_survey(party_id, enrolment_code):
         raise Exception('Failed to add survey')
 
     logger.debug('Successfully added a survey')
+
+
+def get_party_by_email(email):
+    logger.debug('Retrieving party by email address', email=email)
+    url = f'{Config.PARTY_SERVICE}/party-api/v1/respondents/email/{email}'
+    response = requests.get(url, auth=Config.BASIC_AUTH)
+
+    if response.status_code == 404:
+        logger.info('Email not found', email=email)
+        return
+
+    elif response.status_code != 200:
+        logger.error('Error retrieving email address', email=email)
+        raise Exception('Failed to retrieve email address')
+
+    logger.debug('Successfully retrieved email address', email=email)
+    return response.json()


### PR DESCRIPTION
Added tests for changing a respondent's email address.

[Confluence](https://digitaleq.atlassian.net/wiki/spaces/RASB/pages/248545506/US058+Change+Respondents+Email+Address+XL)
[Trello](https://trello.com/c/KQUOeZBV/46-us058-int-change-respondent-email-address-xl)

Should be able to run from master branches.