### PR TITLE
Reduce output of tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,10 +47,10 @@ style_tests:
 	pipenv check --style . --max-line-length 120
 
 system_tests:
-	pipenv run behave system_tests/features # This will only run the system tests
+	pipenv run behave --format progress system_tests/features # This will only run the system tests
 
 acceptance_tests:
-	pipenv run behave acceptance_tests/features # This will only run the acceptance tests
+	pipenv run behave --format progress acceptance_tests/features # This will only run the acceptance tests
 
 test: style_tests start_services system_tests setup acceptance_tests stop_services
 

--- a/run.py
+++ b/run.py
@@ -3,5 +3,5 @@ from behave import __main__ as behave_executable
 
 if __name__ == '__main__':
 
-    behave_executable.main('system_tests/features')
-    behave_executable.main('acceptance_tests/features')
+    behave_executable.main(args='--format progress system_tests/features')
+    behave_executable.main(args='--format progress acceptance_tests/features')


### PR DESCRIPTION
Open for discussion whether or not it's useful, if not I'll close the branch.
Reduces the output of the tests, instead of print off all steps of all features.

* Run `pipenv run python run.py` or `make test` to see the different output.