### PR TITLE
Set user to active in party service when registering

### DIFF
--- a/acceptance_tests/features/environment.py
+++ b/acceptance_tests/features/environment.py
@@ -84,6 +84,7 @@ def poll_database_for_iac(survey_id, period):
 
 
 def register_respondent(survey_id, period, username, ru_ref=None):
+    logger.info('Registering respondent', survey_id=survey_id, period=period, email=username)
     collection_exercise_id = collection_exercise_controller.get_collection_exercise(survey_id, period)['id']
     if ru_ref:
         business_party = party_controller.get_party_by_ru_ref(ru_ref)
@@ -100,6 +101,7 @@ def register_respondent(survey_id, period, username, ru_ref=None):
     django_oauth_controller.verify_user(respondent_party['emailAddress'])
     case_id = database_controller.enrol_party(respondent_party['id'])
     case_controller.post_case_event(case_id, respondent_party['id'], "RESPONDENT_ENROLED", "Respondent enrolled")
+    logger.info('Successfully registered respondent', survey_id=survey_id, period=period, email=username)
     return respondent_party['id']
 
 

--- a/acceptance_tests/features/steps/view_reporting_unit_details.py
+++ b/acceptance_tests/features/steps/view_reporting_unit_details.py
@@ -97,7 +97,7 @@ def internal_internal_user_presented_correct_associated_respondents(_):
     assert associated_respondents[0]['name'] == 'first_name last_name'
     assert associated_respondents[0]['email'] == 'example@example.com'
     assert associated_respondents[0]['phone'] == '0987654321'
-    assert associated_respondents[0]['accountStatus'] == 'Created'
+    assert associated_respondents[0]['accountStatus'] == 'Active'
 
 
 @then('the status \'Completed by phone\' is displayed back to the internal user')

--- a/controllers/database_controller.py
+++ b/controllers/database_controller.py
@@ -117,6 +117,7 @@ def enrol_party(respondent_uuid):
     sql_statement_update_enrolment = f"UPDATE partysvc.enrolment SET status = 'ENABLED' WHERE respondent_id = (SELECT id FROM partysvc.respondent WHERE party_uuid = '{respondent_uuid}');"  # NOQA
     sql_get_case_id = f"SELECT case_id FROM partysvc.pending_enrolment WHERE respondent_id = (SELECT id FROM partysvc.respondent WHERE party_uuid = '{respondent_uuid}');"  # NOQA
     sql_delete_pending_enrolment = f"DELETE FROM partysvc.pending_enrolment WHERE respondent_id = (SELECT id FROM partysvc.respondent WHERE party_uuid = '{respondent_uuid}');"  # NOQA
+    sql_set_account_active = f"UPDATE partysvc.respondent SET status = 'ACTIVE' WHERE party_uuid = '{respondent_uuid}';"  # NOQA
 
     engine = create_engine(Config.PARTY_DATABASE_URI)
     connection = engine.connect()
@@ -128,6 +129,7 @@ def enrol_party(respondent_uuid):
     trans = connection.begin()
     connection.execute(sql_statement_update_enrolment)
     connection.execute(sql_delete_pending_enrolment)
+    connection.execute(sql_set_account_active)
     trans.commit()
 
     return case_id

--- a/controllers/party_controller.py
+++ b/controllers/party_controller.py
@@ -67,8 +67,8 @@ def add_survey(party_id, enrolment_code):
 
 def get_party_by_email(email):
     logger.debug('Retrieving party by email address', email=email)
-    url = f'{Config.PARTY_SERVICE}/party-api/v1/respondents/email/{email}'
-    response = requests.get(url, auth=Config.BASIC_AUTH)
+    url = f'{Config.PARTY_SERVICE}/party-api/v1/respondents/email'
+    response = requests.get(url, auth=Config.BASIC_AUTH, json={"email": email})
 
     if response.status_code == 404:
         logger.info('Email not found', email=email)


### PR DESCRIPTION
The example user `example@example.com` was never being set to active in the party service which wouldn't let them sign in

This is now set in database when a respondent is registered