### PR TITLE
case insensitive text assert

### DIFF
--- a/acceptance_tests/features/steps/edit_respondent_details.py
+++ b/acceptance_tests/features/steps/edit_respondent_details.py
@@ -82,7 +82,7 @@ def confirm_changes_saved(_):
 @then('they are presented with confirmation that the changes have been saved')
 def confirm_email_changes_saved(_):
     contact_details_changes = reporting_unit.get_confirm_contact_details_success_text()
-    assert 'Verification email sent to' in contact_details_changes
+    assert 'verification email sent to' in contact_details_changes.lower()
 
 
 @then('the contact number is not changed')


### PR DESCRIPTION
Changes in https://github.com/ONSdigital/response-operations-ui/pull/142 will break an acceptance test due to case sensitive text assert. This PR is a fix for that.