### PR TITLE
Make waiting for case to update optional when registering a respondent

### DIFF
--- a/acceptance_tests/features/enrolment-status-disable.feature
+++ b/acceptance_tests/features/enrolment-status-disable.feature
@@ -5,7 +5,7 @@ Feature: Disable respondent enrolment status
 
   @us022_s01
   Scenario: Internal user must be able to disable a respondents enrolment
-    Given the respondent with email "disable_respondent_1@email.com" is enrolled
+    Given the respondent with email "disable_respondent_1@email.com" is enrolled and active
     And the internal user is on the ru details page
     When the internal clicks on the disable button for "disable_respondent_1@email.com"
     And the internal user confirms they want to disable the account
@@ -13,15 +13,15 @@ Feature: Disable respondent enrolment status
 
   @us022_s02
   Scenario: Internal user disables a respondents enrolment the respondent should no longer be able to view this enrolment
-    Given the respondent with email "disable_respondent_2@email.com" is enrolled
+    Given the respondent with email "disable_respondent_2@email.com" is enrolled and active
     And the internal user disables enrolment for respondent with email "disable_respondent_2@email.com"
     When the respondent with email "disable_respondent_2@email.com" views their survey todo list
     Then the respondent should not be able to view the disabled enrolment
 
   @us022_s03
   Scenario: Internal user disables a respondents enrolment the other respondent should still see survey
-    Given the respondent with email "disable_respondent_3@email.com" is enrolled
-    And the respondent with email "disable_respondent_4@email.com" is enrolled
+    Given the respondent with email "disable_respondent_3@email.com" is enrolled and active
+    And the respondent with email "disable_respondent_4@email.com" is enrolled and active
     And the internal user disables enrolment for respondent with email "disable_respondent_3@email.com"
     When the respondent with email "disable_respondent_4@email.com" views their survey todo list
     Then the respondent should see the survey in their todo list

--- a/acceptance_tests/features/environment.py
+++ b/acceptance_tests/features/environment.py
@@ -100,7 +100,7 @@ def poll_database_for_iac(survey_id, period):
         time.sleep(5)
 
 
-def register_respondent(survey_id, period, username, ru_ref=None):
+def register_respondent(survey_id, period, username, ru_ref=None, wait_for_case=False):
     logger.info('Registering respondent', survey_id=survey_id, period=period, ru_ref=ru_ref)
     collection_exercise_id = collection_exercise_controller.get_collection_exercise(survey_id, period)['id']
     if ru_ref:
@@ -123,7 +123,8 @@ def register_respondent(survey_id, period, username, ru_ref=None):
     django_oauth_controller.verify_user(respondent_party['emailAddress'])
     case_id = database_controller.enrol_party(respondent_id)
     case_controller.post_case_event(case_id, respondent_id, "RESPONDENT_ENROLED", "Respondent enrolled")
-    wait_for_case_to_update(respondent_id)
+    if wait_for_case:
+        wait_for_case_to_update(respondent_id)
     logger.info('Successfully registered respondent', survey_id=survey_id, period=period,
                 ru_ref=ru_ref, respondent_id=respondent_id)
     return respondent_id

--- a/acceptance_tests/features/steps/edit_respondent_details.py
+++ b/acceptance_tests/features/steps/edit_respondent_details.py
@@ -7,8 +7,13 @@ from controllers.party_controller import get_party_by_email
 
 
 @given('the respondent with email "{email}" is enrolled')
-def respondent_ail_is_enrolled(_, email):
+def respondent_is_enrolled(_, email):
     create_respondent(email)
+
+
+@given('the respondent with email "{email}" is enrolled and active')
+def respondent_is_enrolled(_, email):
+    create_respondent(email, wait=True)
 
 
 @given('the internal user chooses to change "{email}" account details')
@@ -104,8 +109,8 @@ def error_email_already_in_use(_):
     assert reporting_unit.save_email_error()
 
 
-def create_respondent(email):
+def create_respondent(email, wait=False):
     email_in_use = get_party_by_email(email)
     if not email_in_use:
         register_respondent(survey_id='cb8accda-6118-4d3b-85a3-149e28960c54', period='201801',
-                            username=email, ru_ref=49900000001)
+                            username=email, ru_ref=49900000001, wait_for_case=wait)

--- a/controllers/messages_controller.py
+++ b/controllers/messages_controller.py
@@ -33,7 +33,7 @@ def create_message_internal_to_external(subject='Subject', body='Body'):
 
     # Send message
     create_message_internal.click_message_send_button()
-    logger.info("Message from internal to external created")
+    logger.debug("Message from internal to external created")
 
 
 def create_message_external_to_internal(subject='Subject', body='Body'):
@@ -51,4 +51,4 @@ def create_message_external_to_internal(subject='Subject', body='Body'):
 
     # Send message
     create_message_external.send_message()
-    logger.info("Message from external to internal created")
+    logger.debug("Message from external to internal created")


### PR DESCRIPTION
It takes some time for the relevant cases to be updated when we register/enrol a respondent. In some cases we need to wait for this to test but in some cases we don't. 
This PR removes this wait when it is not necessary as it can take some time