### PR TITLE
Fix wait for live

### DIFF
--- a/acceptance_tests/features/pages/reporting_unit.py
+++ b/acceptance_tests/features/pages/reporting_unit.py
@@ -41,6 +41,11 @@ def get_associated_collection_exercises():
     return exercises
 
 
+def get_collection_exercise(exercise_ref, collection_exercises):
+    return next((exercise for exercise in collection_exercises
+                 if exercise['exercise_ref'] == exercise_ref), None)
+
+
 def get_associated_respondents():
     respondents_table = browser.find_by_name('tbl-respondents-for-survey')
     rows = respondents_table.find_by_tag('tbody').find_by_tag('tr')

--- a/acceptance_tests/features/pages/surveys_todo.py
+++ b/acceptance_tests/features/pages/surveys_todo.py
@@ -7,7 +7,7 @@ def go_to():
 
 
 def get_collection_exercise_periods():
-    return browser.find_by_id('SURVEY_PERIOD')
+    return browser.find_by_name('period')
 
 
 def get_surveys_list():

--- a/acceptance_tests/features/steps/view_collection_exercise_live_state.py
+++ b/acceptance_tests/features/steps/view_collection_exercise_live_state.py
@@ -1,10 +1,26 @@
 from datetime import datetime, timedelta
+import time
 
 from behave import given, when, then
 
 from acceptance_tests.features.pages import collection_exercise, collection_exercise_details
 from common.browser_utilities import is_text_present_with_retry
 from controllers import collection_exercise_controller
+
+
+@given('a new exercise with period "{period}" is created and executed for BRICKS')
+def create_execute_new_exercise(_, period):
+    if collection_exercise_controller.get_collection_exercise('cb8accda-6118-4d3b-85a3-149e28960c54', period):
+        return
+    now = datetime.utcnow()
+    dates = {
+        "mps": now + timedelta(seconds=5),
+        "go_live": now + timedelta(minutes=1),
+        "return_by": now + timedelta(days=10),
+        "exercise_end": now + timedelta(days=11)
+    }
+    collection_exercise_controller.create_and_execute_collection_exercise('cb8accda-6118-4d3b-85a3-149e28960c54',
+                                                                          period, 'test_exercise', dates)
 
 
 @given('the user has confirmed that "{survey}" "{period}" is Ready for Live')
@@ -27,15 +43,7 @@ def user_navigate_to_ce_details(_, period):
 
 @when('"{survey}" "{period}" go live date hits')
 def go_live_date_hits(_, survey, period):
-    # PUT to force the scheduler
-    s_id = {
-        'rsi': '75b19ea0-69a4-4c58-8d7f-4458c8f43f5c',
-        'bricks': 'cb8accda-6118-4d3b-85a3-149e28960c54',
-    }[survey.lower()]
-    datetime_ = '2018-01-21T00:00:00.000Z'  # some time in the past
-    date_time = datetime.now() + timedelta(seconds=5)
-    date_time_string = 
-    collection_exercise_controller.update_event_for_collection_exercise(s_id, period, 'go_live', datetime)
+    time.sleep(20)
 
 
 @then('the state of a collection exercise is to be changed to Live')

--- a/acceptance_tests/features/steps/view_collection_exercise_live_state.py
+++ b/acceptance_tests/features/steps/view_collection_exercise_live_state.py
@@ -1,5 +1,4 @@
 from datetime import datetime, timedelta
-import time
 
 from behave import given, when, then
 

--- a/acceptance_tests/features/steps/view_collection_exercise_live_state.py
+++ b/acceptance_tests/features/steps/view_collection_exercise_live_state.py
@@ -9,13 +9,15 @@ from controllers import collection_exercise_controller
 
 
 @given('a new exercise with period "{period}" is created and executed for BRICKS')
-def create_execute_new_exercise(_, period):
+def create_execute_new_exercise(context, period):
     if collection_exercise_controller.get_collection_exercise('cb8accda-6118-4d3b-85a3-149e28960c54', period):
         return
     now = datetime.utcnow()
+    go_live = now + timedelta(minutes=1)
+    context.go_live = go_live
     dates = {
         "mps": now + timedelta(seconds=5),
-        "go_live": now + timedelta(minutes=1),
+        "go_live": go_live,
         "return_by": now + timedelta(days=10),
         "exercise_end": now + timedelta(days=11)
     }
@@ -42,8 +44,10 @@ def user_navigate_to_ce_details(_, period):
 
 
 @when('"{survey}" "{period}" go live date hits')
-def go_live_date_hits(_, survey, period):
-    time.sleep(20)
+def go_live_date_hits(context, survey, period):
+    while True:
+        if datetime.utcnow() > context.go_live:
+            return
 
 
 @then('the state of a collection exercise is to be changed to Live')

--- a/acceptance_tests/features/steps/view_collection_exercise_live_state.py
+++ b/acceptance_tests/features/steps/view_collection_exercise_live_state.py
@@ -1,3 +1,4 @@
+from datetime import datetime, timedelta
 
 from behave import given, when, then
 
@@ -31,7 +32,9 @@ def go_live_date_hits(_, survey, period):
         'rsi': '75b19ea0-69a4-4c58-8d7f-4458c8f43f5c',
         'bricks': 'cb8accda-6118-4d3b-85a3-149e28960c54',
     }[survey.lower()]
-    datetime = '2018-01-21T00:00:00.000Z'  # some time in the past
+    datetime_ = '2018-01-21T00:00:00.000Z'  # some time in the past
+    date_time = datetime.now() + timedelta(seconds=5)
+    date_time_string = 
     collection_exercise_controller.update_event_for_collection_exercise(s_id, period, 'go_live', datetime)
 
 

--- a/acceptance_tests/features/steps/view_reporting_unit_details.py
+++ b/acceptance_tests/features/steps/view_reporting_unit_details.py
@@ -76,10 +76,11 @@ def internal_internal_user_presented_correct_associated_collection_exercises(_):
         browser.reload()
         associated_ces = reporting_unit.get_associated_collection_exercises()
         time.sleep(1)
-    assert associated_ces[0]['exercise_ref'] == '201801'
-    assert associated_ces[0]['company_name'] == 'RUNAME1_COMPANY1 RUNNAME2_COMPANY1'
-    assert associated_ces[0]['company_region'] == 'GB'
-    assert 'Not started' in associated_ces[0]['status'], associated_ces[0]['status']
+    exercise_201801 = reporting_unit.get_collection_exercise('201801', associated_ces)
+    assert exercise_201801['exercise_ref'] == '201801'
+    assert exercise_201801['company_name'] == 'RUNAME1_COMPANY1 RUNNAME2_COMPANY1'
+    assert exercise_201801['company_region'] == 'GB'
+    assert 'Not started' in exercise_201801['status'], exercise_201801['status']
 
 
 @then('the internal user is presented with the associated respondents')

--- a/acceptance_tests/features/steps/view_reporting_unit_details.py
+++ b/acceptance_tests/features/steps/view_reporting_unit_details.py
@@ -76,7 +76,6 @@ def internal_internal_user_presented_correct_associated_collection_exercises(_):
         browser.reload()
         associated_ces = reporting_unit.get_associated_collection_exercises()
         time.sleep(1)
-    assert len(associated_ces) == 2
     assert associated_ces[0]['exercise_ref'] == '201801'
     assert associated_ces[0]['company_name'] == 'RUNAME1_COMPANY1 RUNNAME2_COMPANY1'
     assert associated_ces[0]['company_region'] == 'GB'

--- a/acceptance_tests/features/steps/view_survey_list.py
+++ b/acceptance_tests/features/steps/view_survey_list.py
@@ -12,12 +12,12 @@ def default_pass(context):
 @then('the respondent is displayed that collection exercise')
 def respondent_views_bricks_201801(context):
     ce_periods = get_collection_exercise_periods()
-    for period in ce_periods:
-        assert period.value == 'January 2018'
+    ce_period_values = [ce.value for ce in ce_periods]
+    assert 'January 2018' in ce_period_values
 
 
 @then('the respondent is not displayed that collection exercise')
 def respondent_cant_view_bricks_201812(context):
     ce_periods = get_collection_exercise_periods()
-    for period in ce_periods:
-        assert period.value != 'December 2018'
+    ce_period_values = [ce.value for ce in ce_periods]
+    assert 'December 2018' not in ce_period_values

--- a/acceptance_tests/features/view_collection_exercise_live_state.feature
+++ b/acceptance_tests/features/view_collection_exercise_live_state.feature
@@ -5,21 +5,22 @@ Feature: View live state of a collection exercise
 
   Background: Internal user is already signed in
     Given the internal user is already signed in
+    And a new exercise with period "202001" is created and executed for BRICKS
 
   @us047_s001
   Scenario: The 'Live' state is to be displayed when the collection exercise goes live (the 'go live' date hits) and collection instrument is available to respondent
-    Given the user has confirmed that "bricks" "201801" is Ready for Live
-    When "bricks" "201801" go live date hits
+    Given the user has confirmed that "bricks" "202001" is Ready for Live
+    When "bricks" "202001" go live date hits
     Then the state of a collection exercise is to be changed to Live
 
   @us047_s002
   Scenario: The state can be viewed on the survey details page
     Given the user is on the Survey Page
     When they navigate to the "bricks" page
-    Then they are able to see the Live Status for "201801"
+    Then they are able to see the Live Status for "202001"
 
   @us047_s003
   Scenario: The state can be viewed on the collection exercise details page
     Given the user is on the "bricks" Page
-    When they navigate to the Collection Exercise Details Page for "201801"
+    When they navigate to the Collection Exercise Details Page for "202001"
     Then they are able to see the Live Status for that Collection Exercise


### PR DESCRIPTION
Changes in how we validate collection exercise event dates mean that the previous way we triggered/tested the live state transition of a collection exercise wont work.
We now create a new collection exercise which transitions into a live state over the course of the test

Works with changes in
[ras-frontstage](https://github.com/ONSdigital/ras-frontstage/pull/330)