### PR TITLE
Fixing `make test`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,8 @@ system_tests: TEST_TARGET = system_tests/features  # This will only run the syst
 system_tests: run_tests
 
 acceptance_tests: TEST_TARGET = acceptance_tests/features  # This will only run the acceptance tests
-acceptance_tests: setup run_tests
+acceptance_tests: setup
+	pipenv run behave --format ${BEHAVE_FORMAT} ${TEST_TARGET}
 
 BEHAVE_FORMAT = progress2
 run_tests:


### PR DESCRIPTION
## Background
`make test` is skipping the acceptance tests at the moment.

This change fixes it so the acceptance tests. I am unsure why this fixes
it but it does.

## How to test
Run `make test` and it should run all acceptance tests