### PR TITLE
Update README.md with easier instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ System / API tests for RAS & RM services
 
 ## Running the tests
 
-To override any environmental variables you should export any variables before running the tests with behave e.g. `export HEADLESS=False` or by creating a local `.env` file. Most of the environmental variables are defined in [config.py](config.py)
+To override any environment variables you should export any variables before running the tests with behave e.g. `export HEADLESS=False` or by creating a local `.env` file. Most of the environment variables are defined in [config.py](config.py)
 
 ### Headless
 ```bash
@@ -65,35 +65,34 @@ If any config is updated it also has to be updated in the Jenkinsfile
 
 
 ### Debugging tests in Pycharm
-1. Set the environmental variable in pycharm HEADLESS=FALSE. Some instructions to do that https://www.jetbrains.com/help/pycharm/python-console.html
-1. If running against another environment set any other host environmental variables in pycharm
+1. Set the environment variable in pycharm HEADLESS=FALSE. Some instructions to do that https://www.jetbrains.com/help/pycharm/python-console.html
+1. If running against another environment set any other host environment variables in pycharm
 1. Stick a breakpoint at the point you want to debug
 1. Debug the `run.py` and wait to hit the breakpoint
 
 ### Debugging tests against services deployed in Cloudfoundry
-1. Set Cloudfoundry database environmental variables
-```bash
-export CLOUDFOUNDRY_API=
-export CLOUDFOUNDRY_EMAIL=
-export CLOUDFOUNDRY_PASSWORD=
-export CLOUDFOUNDRY_ORG=
-export CLOUDFOUNDRY_SPACE=
-```
-2. Get database environmental variables `curl -fsSL  https://raw.githubusercontent.com/ONSdigital/ras-deploy/master/scripts/get_database_uris.sh |bash|sed -e 's/@.*:5432/@localhost:5432/g' > setenvs.sh`
-1. Set database environmental variables `source setenvs.sh`
+1. Set Cloudfoundry database environment variables
+    ```bash
+    export CLOUDFOUNDRY_API=
+    export CLOUDFOUNDRY_EMAIL=
+    export CLOUDFOUNDRY_PASSWORD=
+    export CLOUDFOUNDRY_ORG=
+    export CLOUDFOUNDRY_SPACE=
+    ```
+1. Get database environment variables `curl -fsSL  https://raw.githubusercontent.com/ONSdigital/ras-deploy/master/scripts/get_database_uris.sh |bash|sed -e 's/@.*:5432/@localhost:5432/g' > setenvs.sh`
 1. Get database URI `export DATABASE_NAME=$(cf apps | grep ras-collection-instrument-ci-migration | awk ‘{ print “cf env “$1 }‘| bash | grep “postgres://” | awk -F \” ‘{ print $4 }’ | sed ‘s!postgres://.*@\(.*\):.*!\1!’)`
 1. Create an SSH tunnel to the database `cf ssh -L 5432:$DATABASE_NAME:5432 ras-collection-instrument-ci-migration`
 cloudfoundry app name of a service that has a dependency on the database.
-1. Set acceptance tests environmental variables in [config.py](config.py)
-```bash
-export ACTION_SERVICE_HOST=
-export ACTION_SERVICE_PORT=
-...
-export SURVEY_SERVICE_HOST=
-export SURVEY_SERVICE_PORT=
-```
-7. Reset data in cloudfoundry `make setup`
+1. Set environment variables in shell `fly -t ons get-pipeline -p rasrm|sed -n -e '/ras-deploy\/tasks\/rasrm-acceptance-tests\/run_acceptance_tests.yml/,$p'|sed -e '/on_failure/,$d'|tail -n +3|sed -e 's/\"//g'|sed -e 's/\:\ /=/g'|awk '{print "export "$1 }' >> setenvs.sh`
+1. Set database environment variables `source setenvs.sh`
+1. Reset data in cloudfoundry `make setup`
 1. Run tests `pipenv run python run.py`
+
+Note. To run in pycharm you'll need to put the same environment variables in
+1. Copy the environment variables from the concourse pipeline `fly -t ons get-pipeline -p rasrm|sed -n -e '/ras-deploy\/tasks\/rasrm-acceptance-tests\/run_acceptance_tests.yml/,$p'|sed -e '/on_failure/,$d'|tail -n +3|sed -e 's/\"//g'|sed -e 's/\:\ /=/g'|sed -e 's/^[ \t]*//g'|pbcopy'`
+1. Open run configuration for `run.py` by clicking Edit Configuration...
+1. Open the environment variables by clicking the ...
+1. Click the paste icon
 
 ### Troubleshooting
 #### Failing tests


### PR DESCRIPTION
## Background
To debug tests against the CF space we need to set a bunch of
environment variables in a shell and in pycharm. This change has a one
liner to be able to get all of those variables.

## How to review
Follow steps in "Debugging tests against services deployed in Cloudfoundry" and  "To run in pycharm you'll need to put the same environment variables in" and check it works