### PR TITLE
Adding retry mechanism for checking test state

### DIFF
--- a/acceptance_tests/features/steps/external_conversation.py
+++ b/acceptance_tests/features/steps/external_conversation.py
@@ -2,6 +2,7 @@ from behave import given, when, then
 
 from acceptance_tests import browser
 from acceptance_tests.features.pages import external_conversation
+from common.browser_utilities import is_element_present_by_id_with_retry
 
 
 @given('the external user has conversations in their list')
@@ -28,8 +29,8 @@ def go_to_messages_box(_):
 @then('they are able to view a list of external conversations')
 def test_conversation_available(_):
     assert external_conversation.get_page_title() == 'Messages - ONS Business Surveys'
-    assert browser.find_by_id('message-link-1')
-    assert browser.find_by_id('message-link-2')
+    assert is_element_present_by_id_with_retry('message-link-1')
+    assert is_element_present_by_id_with_retry('message-link-2')
 
 
 @then('they are informed that there are no external conversations')

--- a/common/browser_utilities.py
+++ b/common/browser_utilities.py
@@ -7,3 +7,11 @@ def is_text_present_with_retry(text, retries=3, delay=1):
             return True
         browser.reload()
     return False
+
+
+def is_element_present_by_id_with_retry(id, retries=3, delay=1):
+    for attempt in range(retries):
+        if browser.is_element_present_by_id(id, wait_time=delay):
+            return True
+        browser.reload()
+    return False


### PR DESCRIPTION
## Background
The scenario `User is able to view all messages` as an external user has been failing intermittently.

## What has changed
Adding a retry mechanism that reloads the page a few times with a few
seconds delay to give time for any async processes updating data. Not
100% sure if this is a valid fix but it had be run 10s of times locally
with this change with no failures.

## How to test
Re-run the test to check for intermittent failures `make setup && pipenv run behave --format pretty acceptance_tests/features/external_conversation.feature`