### PR TITLE
Stop tests on first failure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,17 +38,17 @@ system_tests: run_tests
 
 acceptance_tests: TEST_TARGET = acceptance_tests/features  # This will only run the acceptance tests
 acceptance_tests: setup
-	pipenv run behave --format ${BEHAVE_FORMAT} ${TEST_TARGET}
+	pipenv run behave --stop --format ${BEHAVE_FORMAT} ${TEST_TARGET}
 
 rasrm_acceptance_tests: TEST_TARGET = acceptance_tests/features
 rasrm_acceptance_tests: TEST_TAGS = ~@secure_messaging
 rasrm_acceptance_tests:
-	pipenv run behave --format ${BEHAVE_FORMAT} --tags ${TEST_TAGS} ${TEST_TARGET}
+	pipenv run behave --stop --format ${BEHAVE_FORMAT} --tags ${TEST_TAGS} ${TEST_TARGET}
 
 secure_messaging_acceptance_tests: TEST_TARGET = acceptance_tests/features
 secure_messaging_acceptance_tests: TEST_TAGS = @secure_messaging
 secure_messaging_acceptance_tests:
-	pipenv run behave --format ${BEHAVE_FORMAT} --tags ${TEST_TAGS} ${TEST_TARGET}
+	pipenv run behave --stop --format ${BEHAVE_FORMAT} --tags ${TEST_TAGS} ${TEST_TARGET}
 
 run_tests:
-	pipenv run behave --format ${BEHAVE_FORMAT} ${TEST_TARGET}
+	pipenv run behave --stop --format ${BEHAVE_FORMAT} ${TEST_TARGET}


### PR DESCRIPTION
# Motivation and Context
Stop tests on first failure so time isn't wasted waiting to find out a
failed build. Also makes it easier to investigate failed builds because
the logs will be closed to the point in time when the failure occurred.

# What has changed
Add stop flag to stop tests on first failure

# How to test?
1. Put `raise Exception` here https://github.com/ONSdigital/rasrm-acceptance-tests/blob/master/acceptance_tests/features/steps/access_eq_collection_exercise.py#L12
2. Run `make test`
3. Observe tests stop immediately after failure

# Links
http://behave.readthedocs.io/en/latest/behave.html#cmdoption-stop
