### PR TITLE
Fix external user no messages test

### DIFF
--- a/acceptance_tests/features/steps/external_conversation.py
+++ b/acceptance_tests/features/steps/external_conversation.py
@@ -2,6 +2,8 @@ from behave import given, when, then
 
 from acceptance_tests import browser
 from acceptance_tests.features.pages import external_conversation
+from config import Config
+from controllers import database_controller
 
 
 @given('the external user has conversations in their list')
@@ -12,7 +14,8 @@ def external_user_has_two_conversations(_):
 
 @given('the external user has no conversations to view')
 def no_conversations_to_view(_):
-    pass
+    database_controller.execute_sql('resources/database/database_reset_secure_message.sql',
+                                    database_uri=Config.SECURE_MESSAGE_DATABASE_URI)
 
 
 @given('they receive a message body with over 80 characters')

--- a/resources/database/database_reset_secure_message.sql
+++ b/resources/database/database_reset_secure_message.sql
@@ -3,6 +3,7 @@
 TRUNCATE securemessage.events CASCADE;
 TRUNCATE securemessage.secure_message CASCADE;
 TRUNCATE securemessage.status CASCADE;
+TRUNCATE securemessage.conversation CASCADE;
 
 ALTER SEQUENCE securemessage.events_id_seq RESTART WITH 1;
 ALTER SEQUENCE securemessage.secure_message_id_seq RESTART WITH 1;


### PR DESCRIPTION
# Motivation and Context
Fixes the failing secure message test

# What has changed
Now clears down the secure messaging database tables before running the test that checks for no messages.

# How to test?
Run the secure message acceptance tests