### PR TITLE
Remove bi/use case events for generating new enrolment codes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ system_tests: run_tests
 
 acceptance_tests: TEST_TARGET = acceptance_tests/features  # This will only run the acceptance tests
 acceptance_tests: setup
-	pipenv run behave --format ${BEHAVE_FORMAT} ${TEST_TARGET}
+	pipenv run behave --stop --format ${BEHAVE_FORMAT} ${TEST_TARGET}
 
 rasrm_acceptance_tests: TEST_TARGET = acceptance_tests/features
 rasrm_acceptance_tests: TEST_TAGS = ~@secure_messaging

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ system_tests: run_tests
 
 acceptance_tests: TEST_TARGET = acceptance_tests/features  # This will only run the acceptance tests
 acceptance_tests: setup
-	pipenv run behave --stop --format ${BEHAVE_FORMAT} ${TEST_TARGET}
+	pipenv run behave --format ${BEHAVE_FORMAT} ${TEST_TARGET}
 
 rasrm_acceptance_tests: TEST_TARGET = acceptance_tests/features
 rasrm_acceptance_tests: TEST_TAGS = ~@secure_messaging

--- a/acceptance_tests/features/environment.py
+++ b/acceptance_tests/features/environment.py
@@ -110,7 +110,7 @@ def register_respondent(survey_id, period, username, ru_ref=None, wait_for_case=
         enrolment_code = database_controller.get_iac_for_collection_exercise_and_business(collection_exercise_id,
                                                                                           business_party['id'])
         if not enrolment_code:
-            enrolment_code = case_controller.generate_new_enrolment_code(collection_exercise_id, ru_ref).get('iac')
+            enrolment_code = case_controller.generate_new_enrolment_code(collection_exercise_id, business_party['id'])
     else:
         enrolment_code = database_controller.get_iac_for_collection_exercise(collection_exercise_id)
     respondent_party = party_controller.register_respondent(email_address=username,

--- a/acceptance_tests/features/environment.py
+++ b/acceptance_tests/features/environment.py
@@ -107,10 +107,10 @@ def register_respondent(survey_id, period, username, ru_ref=None, wait_for_case=
     collection_exercise_id = collection_exercise_controller.get_collection_exercise(survey_id, period)['id']
     if ru_ref:
         business_party = party_controller.get_party_by_ru_ref(ru_ref)
-        b_case = case_controller.get_earliest_b_case(collection_exercise_id, business_party['id'])
+        b_case = case_controller.get_b_case(collection_exercise_id, business_party['id'])
         is_iac_active = iac_controller.get_iac(b_case['iac'])['active']
         if not is_iac_active:
-            enrolment_code = case_controller.generate_new_enrolment_code(collection_exercise_id, business_party['id'])
+            enrolment_code = case_controller.generate_new_enrolment_code(b_case['id'], business_party['id'])
         else:
             enrolment_code = b_case['iac']
     else:

--- a/acceptance_tests/features/environment.py
+++ b/acceptance_tests/features/environment.py
@@ -7,7 +7,7 @@ from structlog import wrap_logger
 from acceptance_tests import browser
 from config import Config
 from controllers import case_controller, collection_exercise_controller, database_controller, \
-    django_oauth_controller, party_controller, sample_controller
+    django_oauth_controller, iac_controller, party_controller, sample_controller
 from controllers.collection_instrument_controller import get_collection_instruments_by_classifier, \
     link_collection_instrument_to_exercise, upload_seft_collection_instrument
 
@@ -107,10 +107,12 @@ def register_respondent(survey_id, period, username, ru_ref=None, wait_for_case=
     collection_exercise_id = collection_exercise_controller.get_collection_exercise(survey_id, period)['id']
     if ru_ref:
         business_party = party_controller.get_party_by_ru_ref(ru_ref)
-        enrolment_code = database_controller.get_iac_for_collection_exercise_and_business(collection_exercise_id,
-                                                                                          business_party['id'])
-        if not enrolment_code:
+        b_case = case_controller.get_earliest_b_case(collection_exercise_id, business_party['id'])
+        is_iac_active = iac_controller.get_iac(b_case['iac'])['active']
+        if not is_iac_active:
             enrolment_code = case_controller.generate_new_enrolment_code(collection_exercise_id, business_party['id'])
+        else:
+            enrolment_code = b_case['iac']
     else:
         enrolment_code = database_controller.get_iac_for_collection_exercise(collection_exercise_id)
     respondent_party = party_controller.register_respondent(email_address=username,

--- a/acceptance_tests/features/steps/display_trading_as_external.py
+++ b/acceptance_tests/features/steps/display_trading_as_external.py
@@ -7,7 +7,7 @@ from acceptance_tests.features.environment import wait_for_ru_specific_cases_to_
 from acceptance_tests.features.pages.surveys_history import go_to_history_tab
 from acceptance_tests.features.pages.surveys_todo import go_to as go_to_todo
 from acceptance_tests.features.steps.authentication import signed_in_respondent
-from controllers.case_controller import generate_new_enrolment_code, update_case_group_status
+from controllers.case_controller import get_b_case, generate_new_enrolment_code, update_case_group_status
 from controllers.collection_exercise_controller import get_collection_exercise
 from controllers.party_controller import add_survey, get_party_by_email, get_party_by_ru_ref
 
@@ -67,8 +67,9 @@ def _get_last_QBS_collection_exercise_id():
 
 
 def _add_survey_for_ru_to_respondent_suppress_exception(respondent_email, ru_ref, collection_exercise_id):
-    business_party = get_party_by_ru_ref(ru_ref)
-    enrolment_code = generate_new_enrolment_code(collection_exercise_id, business_party['id'])
+    business_id = get_party_by_ru_ref(ru_ref)['id']
+    b_case = get_b_case(collection_exercise_id, business_id)
+    enrolment_code = generate_new_enrolment_code(b_case['id'], business_id)
 
     # Suppress exception in case the survey has already been added
     with suppress(Exception):

--- a/acceptance_tests/features/steps/display_trading_as_external.py
+++ b/acceptance_tests/features/steps/display_trading_as_external.py
@@ -9,7 +9,7 @@ from acceptance_tests.features.pages.surveys_todo import go_to as go_to_todo
 from acceptance_tests.features.steps.authentication import signed_in_respondent
 from controllers.case_controller import generate_new_enrolment_code, update_case_group_status
 from controllers.collection_exercise_controller import get_collection_exercise
-from controllers.party_controller import add_survey, get_party_by_email
+from controllers.party_controller import add_survey, get_party_by_email, get_party_by_ru_ref
 
 
 @given('a company with "{ru_ref}" has a separate trading name')
@@ -67,7 +67,8 @@ def _get_last_QBS_collection_exercise_id():
 
 
 def _add_survey_for_ru_to_respondent_suppress_exception(respondent_email, ru_ref, collection_exercise_id):
-    enrolment_code = generate_new_enrolment_code(collection_exercise_id, ru_ref)['iac']
+    business_party = get_party_by_ru_ref(ru_ref)
+    enrolment_code = generate_new_enrolment_code(collection_exercise_id, business_party['id'])
 
     # Suppress exception in case the survey has already been added
     with suppress(Exception):

--- a/controllers/case_controller.py
+++ b/controllers/case_controller.py
@@ -36,8 +36,8 @@ def post_case_event(case_id, party_id, category, description):
     return response.json()
 
 
-def get_earliest_b_case(collection_exercise_id, business_id):
-    logger.debug('Retrieving earliest B case',
+def get_b_case(collection_exercise_id, business_id):
+    logger.debug('Retrieving B case',
                  business_id=business_id, collection_exercise_id=collection_exercise_id)
 
     casegroups = get_casegroups_by_party_id(business_id)
@@ -48,25 +48,22 @@ def get_earliest_b_case(collection_exercise_id, business_id):
     b_case = next(case
                   for case in cases
                   if case['sampleUnitType'] == 'B')
-    logger.debug('Successfully retrieved earliest B case',
+    logger.debug('Successfully retrieved B case',
                  collection_exercise_id=collection_exercise_id, business_id=business_id)
     return b_case
 
 
-def generate_new_enrolment_code(collection_exercise_id, business_id):
-    logger.debug('Generating new enrolment code',
-                 business_id=business_id, collection_exercise_id=collection_exercise_id)
-
-    b_case = get_earliest_b_case(collection_exercise_id, business_id)
-    post_case_event(b_case['id'],
+def generate_new_enrolment_code(case_id, business_id):
+    logger.debug('Generating new enrolment code', case_id=case_id, business_id=business_id)
+    post_case_event(case_id,
                     business_id,
                     'GENERATE_ENROLMENT_CODE',
                     'Generate new enrolment code')
 
     # After posting the case event we also need to retrieve that case again to get the iac
-    updated_case = get_case_by_id(b_case['id'])
+    updated_case = get_case_by_id(case_id)
     logger.debug('Successfully generated new enrolment code',
-                 business_id=business_id, collection_exercise_id=collection_exercise_id)
+                 case_id=case_id, business_id=business_id)
     return updated_case['iac']
 
 

--- a/controllers/case_controller.py
+++ b/controllers/case_controller.py
@@ -8,30 +8,73 @@ from config import Config
 logger = wrap_logger(logging.getLogger(__name__))
 
 
-def post_case_event(case_id, party_uuid, category, description):
-    logger.debug('Post case event')
+def get_case_by_id(case_id):
+    logger.debug('Retrieving case by id', case_id=case_id)
+    url = f'{Config.CASE_SERVICE}/cases/{case_id}'
+    response = requests.get(url, auth=Config.BASIC_AUTH)
+    response.raise_for_status()
+    logger.debug('Successfully retrieved case', case_id=case_id)
+    return response.json()
+
+
+def post_case_event(case_id, party_id, category, description):
+    logger.debug('Posting case event', case_id=case_id, party_id=party_id, category=category)
 
     url = f'{Config.CASE_SERVICE}/cases/{case_id}/events'
     payload = {
         'description': description,
         'category': category,
-        'partyId': party_uuid,
+        'partyId': party_id,
         'createdBy': 'TESTS'
     }
     response = requests.post(url, json=payload, auth=Config.BASIC_AUTH)
     if response.status_code != 201:
         logger.error('Failed to post case event', status=response.status_code)
 
+    logger.debug('Successfully posted case event',
+                 case_id=case_id, party_id=party_id, category=category)
     return response.json()
 
 
-def generate_new_enrolment_code(collection_exercise_id, ru_ref):
-    logger.debug('Generating new enrolment code', collection_exercise_id=collection_exercise_id, ru_ref=ru_ref)
-    url = f'{Config.CASE_SERVICE}/cases/iac/{collection_exercise_id}/{ru_ref}'
-    response = requests.post(url, auth=Config.BASIC_AUTH)
-    response.raise_for_status()
+def generate_new_enrolment_code(collection_exercise_id, business_id):
+    logger.debug('Generating new enrolment code',
+                 business_id=business_id, collection_exercise_id=collection_exercise_id)
+
+    # Have to make a few calls to retrieve the right case for posting case event
+    casegroups = get_casegroups_by_party_id(business_id)
+    casegroup = next(casegroup
+                     for casegroup in casegroups
+                     if collection_exercise_id == casegroup['collectionExerciseId'])
+    cases = get_cases_by_casegroup(casegroup['id'])
+    earliest_case = sorted(cases, key=lambda case: case['createdDateTime'], reverse=True)[0]
+
+    post_case_event(earliest_case['id'],
+                    business_id,
+                    'GENERATE_ENROLMENT_CODE',
+                    'Generate new enrolment code')
+
+    # After posting the case event we also need to retrieve that case again to get the iac
+    updated_case = get_case_by_id(earliest_case['id'])
     logger.debug('Successfully generated new enrolment code',
-                 collection_exercise_id=collection_exercise_id, ru_ref=ru_ref)
+                 business_id=business_id, collection_exercise_id=collection_exercise_id)
+    return updated_case['iac']
+
+
+def get_cases_by_casegroup(casegroup_id):
+    logger.debug('Retrieving cases by casegroup', casegroup_id=casegroup_id)
+    url = f'{Config.CASE_SERVICE}/cases/casegroupid/{casegroup_id}'
+    response = requests.get(url, auth=Config.BASIC_AUTH)
+    response.raise_for_status()
+    logger.debug('Successfully retrieved cases by casegroup', casegroup_id=casegroup_id)
+    return response.json()
+
+
+def get_casegroups_by_party_id(party_id):
+    logger.debug('Retrieving casegroups for party', party_id=party_id)
+    url = f'{Config.CASE_SERVICE}/casegroups/partyid/{party_id}'
+    response = requests.get(url, auth=Config.BASIC_AUTH)
+    response.raise_for_status()
+    logger.debug('Successfully retrieved casegroups for party', party_id=party_id)
     return response.json()
 
 

--- a/controllers/case_controller.py
+++ b/controllers/case_controller.py
@@ -1,5 +1,4 @@
 import logging
-import time
 
 import requests
 from structlog import wrap_logger

--- a/controllers/iac_controller.py
+++ b/controllers/iac_controller.py
@@ -1,0 +1,17 @@
+import logging
+
+import requests
+from structlog import wrap_logger
+
+from config import Config
+
+
+logger = wrap_logger(logging.getLogger(__name__))
+
+
+def get_iac(iac):
+    logger.debug('Retrieving iac', iac=iac)
+    response = requests.get(f'{Config.IAC_SERVICE}/iacs/{iac}', auth=Config.BASIC_AUTH)
+    response.raise_for_status()
+    logger.debug('Successfully retrieved iac', iac=iac)
+    return response.json()

--- a/controllers/party_controller.py
+++ b/controllers/party_controller.py
@@ -1,4 +1,3 @@
-import json
 import logging
 
 import requests

--- a/controllers/party_controller.py
+++ b/controllers/party_controller.py
@@ -29,7 +29,7 @@ def register_respondent(email_address, first_name, last_name, password, phone_nu
         logger.error('Failed to register respondent', status=response.status_code)
         raise Exception('Failed to register respondent')
 
-    return json.loads(response.text)
+    return response.json()
 
 
 def get_respondent_details(respondent_id):

--- a/resources/database/database_reset_rm.sql
+++ b/resources/database/database_reset_rm.sql
@@ -42,12 +42,14 @@ TRUNCATE casesvc.case CASCADE;
 TRUNCATE casesvc.caseevent CASCADE;
 TRUNCATE casesvc.casegroup CASCADE;
 TRUNCATE casesvc.response CASCADE;
+TRUNCATE casesvc.caseiacaudit CASCADE;
 
 ALTER SEQUENCE casesvc.caseeventseq RESTART WITH 1;
 ALTER SEQUENCE casesvc.casegroupseq RESTART WITH 1;
 ALTER SEQUENCE casesvc.caseseq RESTART WITH 1;
 ALTER SEQUENCE casesvc.caserefseq RESTART WITH 1000000000000001;
 ALTER SEQUENCE casesvc.responseseq RESTART WITH 1;
+ALTER SEQUENCE casesvc.caseiacauditseq RESTART WITH 1;
 
 
 /* Clean Action DB */


### PR DESCRIPTION
# Motivation and Context
New enrolment codes are now going to be generated with case events rather than the existing endpoint. The acceptance tests had to be updated to work with these changes.

# What has changed
When retrieving an existing enrolment code we now use casegroups/cases rather than database calls. If the existing code is inactive generate a new one against the found case

# How to test?
Run tests with associated PR's below

# Links
[Trello](https://trello.com/c/npXH3s9x/16-retain-current-enrolment-code-functionality-enrolment-codes)
## PR's
Merge this last after the following below are in:

[case-service](https://github.com/ONSdigital/rm-case-service/pull/51)
[casesvc-api](https://github.com/ONSdigital/rm-casesvc-api/pull/21)
[response-operations-ui](https://github.com/ONSdigital/response-operations-ui/pull/201)