### PR TITLE
Fix redefinition of r-ops system tests

### DIFF
--- a/system_tests/features/steps/get_info_endpoints.py
+++ b/system_tests/features/steps/get_info_endpoints.py
@@ -65,7 +65,7 @@ def requests_response_operations_ui_endpoint_info(context):
 
 
 @when('the system requests respondent home ui endpoint info')
-def requests_response_operations_ui_endpoint_info(context):
+def requests_respondent_home_ui_endpoint_info(context):
     context.response = requests.get(Config.RESPONDENT_HOME_UI + Config.INFO)
 
 


### PR DESCRIPTION
# Motivation and Context
Build is failing on master due to #148 incorrectly redefining a system test method.*

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
Name the new respondent home test correctly.

(* a missed typo)
