### PR TITLE
Add test stability with wait and retries

### DIFF
--- a/acceptance_tests/features/pages/collection_exercise_details.py
+++ b/acceptance_tests/features/pages/collection_exercise_details.py
@@ -33,6 +33,7 @@ def select_sample(sample_file_path):
 
 def load_sample(sample_file_path):
     select_sample(sample_file_path)
+    browser.is_element_visible_by_css('#btn-load-sample', 3)
     browser.find_by_id('btn-load-sample').click()
 
 

--- a/acceptance_tests/features/steps/view_collection_exercise_live_state.py
+++ b/acceptance_tests/features/steps/view_collection_exercise_live_state.py
@@ -27,6 +27,7 @@ def create_execute_new_exercise(context, period):
 @given('the user has confirmed that "{survey}" "{period}" is Ready for Live')
 def internal_user_views_ready_for_live(_, survey, period):
     collection_exercise_details.go_to(survey, period)
+    is_text_present_with_retry('Ready for live', 10)
     ce_state = collection_exercise_details.get_status()
     assert collection_exercise.is_ready_for_live(ce_state), ce_state
 


### PR DESCRIPTION
# Motivation and Context
Step `the user has confirmed that "{survey}" "{period}" is Ready for Live` failed where the collection exercise wasn't yet in `Ready for live`
Load sample failed where the load-sample-btn didn't exist.
 
# What has changed
* Add wait for element to be visible for load sample button as it is
  rendered by javascript and may not be visible on page load
* Add check for text with retry for Ready for Live as this is an async
  process. The collection exercise might not be in that state at the
  time of running that step

# How to test?
Run the acceptance tests