### PR TITLE
Remove manual creation of action rules

### DIFF
--- a/acceptance_tests/features/steps/notification_letter.py
+++ b/acceptance_tests/features/steps/notification_letter.py
@@ -25,7 +25,7 @@ def reporting_unit_enrolled(context):
     }
     # Create action rule
     create_and_execute_collection_exercise('cb8accda-6118-4d3b-85a3-149e28960c54', '0718', 'Testing notification file',
-                                           dates, short_name='Bricks')
+                                           dates)
 
 
 @when('the survey goes live')

--- a/controllers/collection_exercise_controller.py
+++ b/controllers/collection_exercise_controller.py
@@ -9,7 +9,6 @@ from acceptance_tests.features.environment import poll_database_for_iac
 from config import Config
 from controllers import collection_instrument_controller as ci_controller,\
     sample_controller
-from controllers.action_controller import create_action_rule
 
 logger = wrap_logger(logging.getLogger(__name__))
 
@@ -147,7 +146,7 @@ def create_collection_exercise(survey_id, period, user_description):
     logger.debug('Successfully created collection exercise', survey_id=survey_id, period=period)
 
 
-def create_and_execute_collection_exercise(survey_id, period, user_description, dates, short_name=None):
+def create_and_execute_collection_exercise(survey_id, period, user_description, dates):
     create_collection_exercise(survey_id, period, user_description)
     collection_exercise = get_collection_exercise(survey_id, period)
     collection_exercise_id = collection_exercise['id']
@@ -166,8 +165,6 @@ def create_and_execute_collection_exercise(survey_id, period, user_description, 
     ci_controller.upload_seft_collection_instrument(collection_exercise['id'],
                                                     'resources/collection_instrument_files/064_201803_0001.xlsx')
 
-    if short_name:
-        create_action_rule(short_name, period)
     time.sleep(5)
     execute_collection_exercise(survey_id, period)
     iac = poll_database_for_iac(survey_id, period)


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Currently action rules are created manually by hitting action rules
API. The action rules will be created automatically when collection
exercise events are created. This reomves the need to hit the action
rules endpoint.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
Remove manual action rules creation.

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
Run acceptance test

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
https://github.com/ONSdigital/rm-collection-exercise-service/pull/96
https://trello.com/c/Eknzy8H2/119-tbl123-link-action-rules-to-action-plans-at-create-time-create