### PR TITLE
Round start time down to nearest minute

### DIFF
--- a/acceptance_tests/features/steps/notification_letter.py
+++ b/acceptance_tests/features/steps/notification_letter.py
@@ -61,5 +61,11 @@ def retrying_get_file_after_time(client, start_of_test):
 
     latest_file_attributes = files[0]
     with client.open(f'{Config.SFTP_DIR}/{latest_file_attributes.filename}') as latest_file:
+        start_of_test = round_to_minute(start_of_test) # SFTP time is only accurate to the minute
         return str(latest_file.read()) if datetime.fromtimestamp(
-            latest_file_attributes.st_mtime) > start_of_test else None
+            latest_file_attributes.st_mtime) >= start_of_test else None
+
+
+def round_to_minute(start_of_test):
+    return datetime(start_of_test.year, start_of_test.month, start_of_test.day, start_of_test.hour,
+                    start_of_test.minute, second=0, microsecond=0)


### PR DESCRIPTION
# Motivation and Context
SFTP seems to check for a newer file even though the file it's expecting
is there. This could be because the precision of SFTP time is only to
the minute.

# What has changed
Round start time down to the nearest minute

# How to test?
* Run acceptance tests where the test time is in the same minute as the file is put on the SFTP

# Links
https://trello.com/c/Ii0xwuGt/225-add-acceptance-test-for-generating-notification-file