### PR TITLE
Classifiertypeselector fk violation

### DIFF
--- a/resources/database/database_reset_rm.sql
+++ b/resources/database/database_reset_rm.sql
@@ -17,6 +17,7 @@ ALTER SEQUENCE notifygatewaysvc.messageseq RESTART WITH 1;
 
 /* Remove test surveys (deemed to be any survey with survey ref > 999) */
 
+DELETE FROM survey.classifiertype WHERE classifiertypeselectorfk IN (SELECT classifiertypeselectorpk from survey.classifiertypeselector cts JOIN survey.survey s ON cts.surveyfk = s.surveypk WHERE surveyref::int > 999);
 DELETE FROM survey.classifiertypeselector WHERE surveyfk IN (SELECT surveypk FROM survey.survey WHERE surveyref::int > 999);
 DELETE FROM survey.survey WHERE surveyref::text::int > 999;
 UPDATE survey.survey SET shortname = 'NBS', longname = 'National Balance Sheet' WHERE id = '7a2c9d6c-9aaf-4cf0-a68c-1d50b3f1b296' and surveyref = '199';

--- a/resources/database/database_reset_rm.sql
+++ b/resources/database/database_reset_rm.sql
@@ -17,6 +17,7 @@ ALTER SEQUENCE notifygatewaysvc.messageseq RESTART WITH 1;
 
 /* Remove test surveys (deemed to be any survey with survey ref > 999) */
 
+TRUNCATE survey.classifiertypeselector CASCADE;
 DELETE FROM survey.survey WHERE surveyref::text::int > 999;
 UPDATE survey.survey SET shortname = 'NBS', longname = 'National Balance Sheet' WHERE id = '7a2c9d6c-9aaf-4cf0-a68c-1d50b3f1b296' and surveyref = '199';
 

--- a/resources/database/database_reset_rm.sql
+++ b/resources/database/database_reset_rm.sql
@@ -17,7 +17,7 @@ ALTER SEQUENCE notifygatewaysvc.messageseq RESTART WITH 1;
 
 /* Remove test surveys (deemed to be any survey with survey ref > 999) */
 
-TRUNCATE survey.classifiertypeselector CASCADE;
+DELETE FROM survey.classifiertypeselector WHERE surveyfk IN (SELECT surveypk FROM survey.survey WHERE surveyref::int > 999);
 DELETE FROM survey.survey WHERE surveyref::text::int > 999;
 UPDATE survey.survey SET shortname = 'NBS', longname = 'National Balance Sheet' WHERE id = '7a2c9d6c-9aaf-4cf0-a68c-1d50b3f1b296' and surveyref = '199';
 


### PR DESCRIPTION
# Motivation and Context
The acceptance test will fail if the tests are ran twice because of a fk violation. This change deletes those records.

# What has changed
Delete records that have fk violation

# How to test?
Run the acceptance tests twice in a row

# Links
https://trello.com/c/wdlb13a3/193-create-acceptance-tests-for-enrolment-journey-5
