### PR TITLE
Retry on connection reset

### DIFF
--- a/acceptance_tests/__init__.py
+++ b/acceptance_tests/__init__.py
@@ -6,12 +6,17 @@ from selenium import webdriver
 from splinter import Browser
 from structlog import configure
 from structlog.stdlib import LoggerFactory
+from urllib3.exceptions import ProtocolError
 
 logging.basicConfig()
 configure(logger_factory=LoggerFactory())
 
 
-@retry(retry_on_exception=lambda e: isinstance(e, ConnectionError), wait_fixed=1000, stop_max_attempt_number=30)
+def web_driver_connection_error(e):
+    return isinstance(e, ConnectionError) or isinstance(e, ProtocolError)
+
+
+@retry(retry_on_exception=web_driver_connection_error, wait_fixed=1000, stop_max_attempt_number=30)
 def create_browser():
     if os.getenv('HEADLESS', 'True') == 'True':
         chrome_options = webdriver.ChromeOptions()


### PR DESCRIPTION
# Motivation and Context
One the 522 build on the ci-rasrm-acceptance-tests job in the rasrm
pipeline the tests failed because of a connection reset by peer. Don't
think we can do anything at that point other than retry.

# What has changed
Retry for connection reset by peer

# How to test?
1. Add `raise ProtocolError` to line 21 and check it retries on the error

# Links
https://$concourse/teams/rmras/pipelines/rasrm/jobs/ci-rasrm-acceptance-tests/builds/522