### PR TITLE
1st stage of button id naming

### DIFF
--- a/acceptance_tests/features/pages/add_survey.py
+++ b/acceptance_tests/features/pages/add_survey.py
@@ -7,7 +7,7 @@ def go_to():
 
 
 def get_access_survey_button():
-    sign_in_button = browser.find_by_id('SIGN_IN_BUTTON')
+    sign_in_button = browser.find_by_id('sign_in_button')
     sign_in_button.click()
 
 
@@ -16,5 +16,5 @@ def enter_enrolment_code(enrolment_code):
 
 
 def click_continue_button():
-    browser.find_by_id('CONTINUE_BTN').click()
-    browser.find_by_id('CONFIRM_SURVEY_BTN').click()
+    browser.find_by_id('continue_button').click()
+    browser.find_by_id('confirm_survey_button').click()

--- a/acceptance_tests/features/pages/forgotten_password_respondent.py
+++ b/acceptance_tests/features/pages/forgotten_password_respondent.py
@@ -16,7 +16,7 @@ def enter_invalid_username():
 
 
 def send_reset_link():
-    browser.find_by_id('reset-password-btn').click()
+    browser.find_by_id('reset_password_button').click()
 
 
 def password_reset_sent():

--- a/acceptance_tests/features/pages/sign_in_respondent.py
+++ b/acceptance_tests/features/pages/sign_in_respondent.py
@@ -11,7 +11,7 @@ def sign_in_alternate_respondent():
     if '/sign-in' in browser.url:
         browser.driver.find_element_by_id('username').send_keys(Config.RESPONDENT_USERNAME)
         browser.driver.find_element_by_id('password').send_keys(Config.RESPONDENT_PASSWORD)
-        browser.find_by_id('SIGN_IN_BUTTON').click()
+        browser.find_by_id('sign_in_button').click()
 
 
 def signed_in_respondent_with_email(email):
@@ -19,4 +19,4 @@ def signed_in_respondent_with_email(email):
     if '/sign-in' in browser.url:
         browser.driver.find_element_by_id('username').send_keys(email)
         browser.driver.find_element_by_id('password').send_keys(Config.RESPONDENT_PASSWORD)
-        browser.find_by_id('SIGN_IN_BUTTON').click()
+        browser.find_by_id('sign_in_button').click()

--- a/acceptance_tests/features/pages/view_and_reply_conversation_external.py
+++ b/acceptance_tests/features/pages/view_and_reply_conversation_external.py
@@ -41,7 +41,7 @@ def get_text_from_reply_text_area():
 
 
 def click_reply_send_button():
-    browser.driver.find_element_by_id("send-message-btn").click()
+    browser.driver.find_element_by_id("send_message_button").click()
 
 
 def get_latest_message_by_tag():

--- a/acceptance_tests/features/steps/add_a_survey.py
+++ b/acceptance_tests/features/steps/add_a_survey.py
@@ -15,7 +15,7 @@ def surveys_to_do_list(context):
 @when('they add a new survey')
 @then('they are able to add a new survey')
 def add_a_new_survey(context):
-    browser.find_by_id('ADD_SURVEY_BTN').click()
+    browser.find_by_id('add_survey_button').click()
 
 
 @then('they are able to enter an enrolment code')
@@ -29,7 +29,7 @@ def enter_valid_enrolment_code(context):
     add_survey.go_to()
     enrolment_code = select_iac()
     browser.driver.find_element_by_id('ENROLEMENT_CODE_FIELD').send_keys(enrolment_code)
-    browser.find_by_id('CONTINUE_BTN').click()
+    browser.find_by_id('continue_button').click()
 
 
 @then('they are to be presented with the survey and organisation that they are enrolling for')
@@ -40,7 +40,7 @@ def view_confirmation_page(context):
 @when('they enter an invalid enrolment code')
 def enter_invalid_enrolment_code(context):
     browser.driver.find_element_by_id('ENROLEMENT_CODE_FIELD').send_keys('222thu78nj7m')
-    browser.find_by_id('CONTINUE_BTN').click()
+    browser.find_by_id('continue_button').click()
 
 
 @then('they are to be notified')
@@ -50,7 +50,7 @@ def invalid_enrolment_code_notification(context):
 
 @when('they continue and confirm that the organisation and survey that they are enrolling for is correct')
 def confirm_organisation_and_continue(context):
-    browser.find_by_id('CONFIRM_SURVEY_BTN').click()
+    browser.find_by_id('confirm_survey_button').click()
 
 
 @then('the new survey is to be listed in My Surveys and confirmation is presented to the user')
@@ -60,7 +60,7 @@ def confirmation_presented_for_new_survey(context):
 
 @when('they navigate to the confirm organisation page and click cancel')
 def click_cancel(context):
-    browser.find_by_id('CANCEL_BTN').click()
+    browser.find_by_id('cancel_button').click()
 
 
 @then('the user is navigated back to their "To do" list and they have not enrolled for that survey')

--- a/acceptance_tests/features/steps/authentication.py
+++ b/acceptance_tests/features/steps/authentication.py
@@ -13,7 +13,7 @@ def signed_in_respondent(_):
     if '/sign-in' in browser.url:
         browser.driver.find_element_by_id('username').send_keys(Config.RESPONDENT_USERNAME)
         browser.driver.find_element_by_id('password').send_keys(Config.RESPONDENT_PASSWORD)
-        browser.find_by_id('SIGN_IN_BUTTON').click()
+        browser.find_by_id('sign_in_button').click()
 
 
 @given('The internal user is already signed in')

--- a/acceptance_tests/features/steps/survey_enrolment.py
+++ b/acceptance_tests/features/steps/survey_enrolment.py
@@ -25,7 +25,7 @@ def generate_enrolment_code(context):
 @when('they enter their enrolment code')
 def enter_enrolment_code(context):
     browser.driver.find_element_by_id('enrolment_code').send_keys(context.iac)
-    browser.find_by_id('CONTINUE_BUTTON').click()
+    browser.find_by_id('continue_button').click()
 
 
 @then('they confirm the survey and organisation details')
@@ -57,7 +57,7 @@ def complete_account_details(context):
     browser.driver.find_element_by_id('password_confirm').send_keys('A234567_')
     browser.driver.find_element_by_id('phone_number').send_keys('01172345678')
 
-    browser.find_by_id('continue-button').click()
+    browser.find_by_id('continue_button').click()
 
 
 @then('they are sent a verification email')


### PR DESCRIPTION
# Motivation and Context
Make frontstage button id naming consistent.

# What has changed
changed button ids in rasrm-acceptance-tests & ras-frontstage repos

# How to test?
test with ras-frontstage "inconsistant_html_button_id_naming" branch running locally in PyCharm etc... or from local docker image i.e docker build -t frontstage-ade .
all acceptance tests should pass.

# Links
https://github.com/ONSdigital/ras-frontstage/pull/381