### PR TITLE
Only attempt to cast/remove numeric survey refs in setup script

### DIFF
--- a/resources/database/database_reset_rm.sql
+++ b/resources/database/database_reset_rm.sql
@@ -17,9 +17,9 @@ ALTER SEQUENCE notifygatewaysvc.messageseq RESTART WITH 1;
 
 /* Remove test surveys (deemed to be any survey with survey ref > 999) */
 
-DELETE FROM survey.classifiertype WHERE classifiertypeselectorfk IN (SELECT classifiertypeselectorpk from survey.classifiertypeselector cts JOIN survey.survey s ON cts.surveyfk = s.surveypk WHERE surveyref::int > 999);
-DELETE FROM survey.classifiertypeselector WHERE surveyfk IN (SELECT surveypk FROM survey.survey WHERE surveyref::int > 999);
-DELETE FROM survey.survey WHERE surveyref::text::int > 999;
+DELETE FROM survey.classifiertype WHERE classifiertypeselectorfk IN (SELECT classifiertypeselectorpk from survey.classifiertypeselector cts JOIN survey.survey s ON cts.surveyfk = s.surveypk WHERE CASE WHEN surveyref ~ '[^0-9]' THEN 0 ELSE surveyref::integer END > 999);
+DELETE FROM survey.classifiertypeselector WHERE surveyfk IN (SELECT surveypk FROM survey.survey WHERE CASE WHEN surveyref ~ '[^0-9]' THEN 0 ELSE surveyref::integer END > 999);
+DELETE FROM survey.survey WHERE CASE WHEN surveyref ~ '[^0-9]' THEN 0 ELSE surveyref::integer END > 999;
 UPDATE survey.survey SET shortname = 'NBS', longname = 'National Balance Sheet' WHERE id = '7a2c9d6c-9aaf-4cf0-a68c-1d50b3f1b296' and surveyref = '199';
 
 /* Clean And Reset Collection Exercise DB */


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Survey ref is now allowed to be alphanumeric but one of the setup scripts in the acceptance tests casts it to an `int` for teardown, causing an error if you have any non numeric surveys in your database.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
* Added regex check to the SQL script so it does not attempt to cast surveyref to integer if it contains any non numeric characters. Surveys with alphanumeric characters will be ignored by the teardown, preserving the current behaviour of removing any survey with numeric reference greater than 999.

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
Create a survey with non numeric characters in the survey ref. Run the acceptance tests, the setup up should run normally and not tear down the survey you created outside the tests.

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
https://github.com/ONSdigital/rm-survey-service/pull/55