### PR TITLE
Remove reset of removed tables

### DIFF
--- a/resources/database/database_reset_rm.sql
+++ b/resources/database/database_reset_rm.sql
@@ -75,8 +75,6 @@ TRUNCATE actionexporter.actionrequest CASCADE;
 TRUNCATE actionexporter.address CASCADE;
 TRUNCATE actionexporter.contact CASCADE;
 TRUNCATE actionexporter.filerowcount CASCADE;
-TRUNCATE actionexporter.report CASCADE;
 
 ALTER SEQUENCE actionexporter.actionrequestpkseq RESTART WITH 1;
 ALTER SEQUENCE actionexporter.contactpkseq RESTART WITH 1;
-ALTER SEQUENCE actionexporter.reportpkseq RESTART WITH 1;


### PR DESCRIPTION
# Motivation and Context
We no longer use the report table or sequence so removing reference to
them. This was removed in
https://github.com/ONSdigital/rm-actionexporter-service/pull/52

# What has changed
Remove reference to table and sequence

# How to test?
Using https://github.com/ONSdigital/rm-actionexporter-service/pull/52 run all the services then `make wait_for_services setup acceptance_tests`