### PR TITLE
Remove 'GMT' and use localised time

### DIFF
--- a/acceptance_tests/features/steps/view_collection_exercise_details.py
+++ b/acceptance_tests/features/steps/view_collection_exercise_details.py
@@ -31,11 +31,11 @@ def internal_user_can_view_qbs_2018_collection_exercise_details(_):
 @then('the user is able to view the event dates for that collection exercise')
 def internal_user_can_view_qbs_2018_collection_exercise_events(_):
     ce_events = collection_exercise_details.get_collection_exercise_events()
-    assert ce_events['mps'] == "Wednesday 14 Mar 2018 00:00 GMT"
-    assert ce_events['go_live'] == "Monday 19 Mar 2018 00:00 GMT"
-    assert ce_events['return_by'] == "Tuesday 27 Mar 2018 00:00 GMT"
-    assert ce_events['first_reminder'] == "Tuesday 03 Apr 2018 00:00 GMT"
-    assert ce_events['exercise_end'] == "Thursday 30 Apr 2020 00:00 GMT"
+    assert ce_events['mps'] == "Wednesday 14 Mar 2018 00:00"
+    assert ce_events['go_live'] == "Monday 19 Mar 2018 00:00"
+    assert ce_events['return_by'] == "Tuesday 27 Mar 2018 01:00"
+    assert ce_events['first_reminder'] == "Tuesday 03 Apr 2018 01:00"
+    assert ce_events['exercise_end'] == "Thursday 30 Apr 2020 01:00"
 
 
 @then('the user is able to view the variable event dates for that collection exercise')
@@ -44,5 +44,5 @@ def internal_user_can_view_qbs_2018_collection_exercise_variable_event_dates(_):
     assert ce_events['ref_period_start'] == "Friday 09 Mar 2018"
     assert ce_events['ref_period_end'] == "Saturday 31 Mar 2018"
     assert ce_events['employment'] == "Friday 09 Mar 2018"
-    assert ce_events['second_reminder'] == "Monday 23 Apr 2018 00:00 GMT"
-    assert ce_events['third_reminder'] == "Saturday 05 May 2018 00:00 GMT"
+    assert ce_events['second_reminder'] == "Monday 23 Apr 2018 01:00"
+    assert ce_events['third_reminder'] == "Saturday 05 May 2018 01:00"


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Currently time shows up with hard coded 'GMT' at the end. This has
been removed in response operations and now shows localised time.
Acceptance tests have been updated to accomodate this change.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
Ran with branch -> https://github.com/ONSdigital/response-operations-ui/pull/235

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
