### PR TITLE
Updating tests to work with creating secure-messages on frontstage

### DIFF
--- a/acceptance_tests/features/pages/create_message_external.py
+++ b/acceptance_tests/features/pages/create_message_external.py
@@ -9,6 +9,17 @@ def enter_valid_body(body):
     browser.driver.find_element_by_id('secure-message-body').send_keys(body)
 
 
+def get_subject_and_body():
+    form_text_fields = browser.find_by_id("secure-message-form").first
+    form_text_field_attributes = {'subject': form_text_fields.find_by_id('secure-message-subject').value,
+                                  'body': form_text_fields.find_by_id('secure-message-body').value}
+    return form_text_field_attributes
+
+
+def get_message_body_text():
+    return get_subject_and_body().get('body')
+
+
 def enter_valid_body_over_80_character_summary():
     browser.driver.find_element_by_id('secure-message-body').send_keys('I would like to query data. ' * 5)
 

--- a/acceptance_tests/features/send_message_from_todo_list.feature
+++ b/acceptance_tests/features/send_message_from_todo_list.feature
@@ -34,8 +34,8 @@ Feature: Send message from todo list
   @sm137-05
   Scenario: Body field can be max 10000 characters long
     Given the respondent chooses to send a message to ONS
-    When They enter text in the body of the external message
-    Then They are able to enter up to and including 10,000 characters
+    When they enter text in the body of the external message
+    Then they are able to enter up to and including 10,000 characters
 
   @sm137-06
   Scenario: Body and Subject fields must be populated

--- a/acceptance_tests/features/send_message_from_todo_list.feature
+++ b/acceptance_tests/features/send_message_from_todo_list.feature
@@ -34,9 +34,8 @@ Feature: Send message from todo list
   @sm137-05
   Scenario: Body field can be max 10000 characters long
     Given the respondent chooses to send a message to ONS
-    When the respondent enters more than 10000 characters in the body field
-    And selects to send message
-    Then an error message appears specifying body too long
+    When They enter text in the body of the external message
+    Then They are able to enter up to and including 10,000 characters
 
   @sm137-06
   Scenario: Body and Subject fields must be populated

--- a/acceptance_tests/features/steps/send_message_from_todo_list.py
+++ b/acceptance_tests/features/steps/send_message_from_todo_list.py
@@ -2,6 +2,7 @@ from behave import given, when, then
 
 from acceptance_tests import browser
 from acceptance_tests.features.pages import surveys_todo, create_message_external
+import acceptance_tests.features.pages.view_and_reply_conversation_external as page_helpers
 
 
 @given('the respondent is on their todo list')
@@ -26,6 +27,18 @@ def select_create_message(_):
 @then('the respondent is navigated to the create message page')
 def assert_create_message_page(_):
     browser.find_by_id('secure-message-subject')
+
+
+@then('They are able to enter up to and including 10,000 characters')
+def enter_text_body_up_to_10000_characters(_):
+    # Check user can enter 10000 characters
+    page_helpers.enter_text_in_conversation_reply_with_javascript('a' * 9900)
+    page_helpers.enter_text_in_conversation_reply('a' * 100)
+    assert page_helpers.get_text_from_reply_text_area() == 'a' * 10000
+
+    # Check user cannot enter more than 10000 characters
+    page_helpers.enter_text_in_conversation_reply('a' * 100)
+    assert page_helpers.get_text_from_reply_text_area() == 'a' * 10000
 
 
 @when('the respondent enters a valid message')
@@ -108,3 +121,10 @@ def populate_subject_no_body(_):
 @then('an error message appears notifying the respondent a body must be supplied')
 def assert_error_no_body(_):
     browser.driver.find_element_by_link_text('Please enter a message')
+
+
+@when("they enter text in the body of the external message")
+def user_enters_text_in_message_body(_):
+    create_message_external.enter_valid_body('Message body')
+    assert create_message_external.get_message_body_text() == 'Message body'
+    create_message_external.empty_body()


### PR DESCRIPTION
# Motivation and Context
On frontstage, The WAF gets triggered when a respondent types in more than 10,000 characters when creating a message. This PR is associated with the a branch on Frontstage- [Frontstage PR](https://github.com/ONSdigital/ras-frontstage/pull/394)

# What has changed
- Changed steps for creating a message so it goes up to 10,000 characters and not over

# How to test?
- Run acceptance tests with respective PR and all tests should pass

# Links
[Trello card](https://trello.com/c/1Oga8Jnv/317-frontstage-secure-message-rejected-by-waf-if-the-body-is-too-long)

### This needs to be merged in with the branch on Frontstage