### PR TITLE
Fix intermittently failing test

### DIFF
--- a/acceptance_tests/features/steps/view_collection_exercise_live_state.py
+++ b/acceptance_tests/features/steps/view_collection_exercise_live_state.py
@@ -12,7 +12,7 @@ def create_execute_new_exercise(context, period):
     if collection_exercise_controller.get_collection_exercise('cb8accda-6118-4d3b-85a3-149e28960c54', period):
         return
     now = datetime.utcnow()
-    go_live = now + timedelta(minutes=1)
+    go_live = now + timedelta(minutes=2)
     context.go_live = go_live
     dates = {
         "mps": now + timedelta(seconds=5),


### PR DESCRIPTION
# Motivation and Context
The test `a new exercise with period "X" is created and executed for BRICKS` in `view_collection_exercise_live_state.py` was setting a go_live date of 1 minute from the present time, which was not enough time for the sample units to be delivered, processed and the state to transition to `READY_FOR_LIVE` so the state transition was failing when the event message was processed.

# What has changed
Increased the amount of time to 2 minutes.

# How to test?
It's intermittent so it's hard to reproduce. Run the ATs and make sure they're still working.

# Links
Trello: https://trello.com/c/4Sx9t8R4/389-bug-fix-acceptance-test-intermittent-hanging