### PR TITLE
Increase timeout for SFTP connection to stop notify AT intermittent fail

### DIFF
--- a/acceptance_tests/features/steps/notification_letter.py
+++ b/acceptance_tests/features/steps/notification_letter.py
@@ -53,7 +53,8 @@ def _get_sftp_client():
                 port=int(Config.SFTP_PORT),
                 username=Config.SFTP_USERNAME,
                 password=Config.SFTP_PASSWORD,
-                look_for_keys=False)
+                look_for_keys=False,
+                timeout=120)
     return ssh.open_sftp()
 
 


### PR DESCRIPTION
# Motivation and Context
We are regularly seeing the acceptance test `the reporting unit will receive a letter` fail because of SFTP connection problems connecting to our FTP host. The logs say that it's a connection timeout on authentication so it seems reasonable that we should increase the amount of time before we get a timeout, given that I can connect without a problem to the SFTP host.

# What has changed
Increased connection timeout to 2 minutes.

# How to test?
Intermittent, so hard to reproduce. Run the ATs and make sure there's no regression.

# Links
Trello: https://trello.com/c/EzTfnHBO/400-bug-sftp-connection-timeout-in-acceptance-tests-checking-for-notify-letter