### PR TITLE
Add log line to help diagnose bug

### DIFF
--- a/acceptance_tests/features/steps/notification_letter.py
+++ b/acceptance_tests/features/steps/notification_letter.py
@@ -41,6 +41,7 @@ def letter_is_received(context):
 
         with client.open(file_path) as sftp_file:
             content = str(sftp_file.read())
+            logger.info('Checking file contains IAC code', file_path=file_path, iac_code=context.iac_code)
             assert context.iac_code in content, content
             client.remove(file_path)  # Only delete file if test passes
 

--- a/wait_until_services_up.py
+++ b/wait_until_services_up.py
@@ -18,7 +18,7 @@ def retry_if_http_error(exception):
     return isinstance(exception, RequestException) or isinstance(exception, HealthCheckException)
 
 
-@retry(retry_on_exception=retry_if_http_error, wait_fixed=10000, stop_max_delay=600000, wrap_exception=True)
+@retry(retry_on_exception=retry_if_http_error, wait_fixed=10000, stop_max_delay=1200000, wrap_exception=True)
 def check_status(url):
     try:
         resp = requests.get(f'{url}/info')


### PR DESCRIPTION
# Motivation and Context
When investigating a failed acceptance test, it was found that 2 files were created on the SFTP server in quick succession. There is insufficient logging to know which file the acceptance test is opening, and what IAC code it's looking for inside the file. This PR adds extra logging to the test so we can diagnose whether we need to fix the test or the Action Exporter service.

# What has changed
Added extra logging to `the reporting unit will receive a letter` scenario.

# How to test?
Run the acceptance tests and check that we're getting the extra log output.

# Links
Trello: https://trello.com/c/MLoPHcVk/402-bug-check-for-iac-code-in-sftp-file-intermittently-causes-ats-to-fail