### PR TITLE
Added wait between signng in and viewing history tab

### DIFF
--- a/acceptance_tests/features/steps/change_response_status.py
+++ b/acceptance_tests/features/steps/change_response_status.py
@@ -1,3 +1,5 @@
+import time
+
 from datetime import datetime, timedelta
 
 from behave import when, given, then
@@ -61,6 +63,7 @@ def respondent_enrolled_for_ce(_, survey, period, ru_ref):
 @when('the respondent goes to the history page')
 def respondent_goes_to_history_page_for_49900000002(_):
     signed_in_respondent(_)
+    time.sleep(60)
     surveys_history.go_to_history_tab()
 
 

--- a/acceptance_tests/features/steps/change_response_status.py
+++ b/acceptance_tests/features/steps/change_response_status.py
@@ -63,7 +63,7 @@ def respondent_enrolled_for_ce(_, survey, period, ru_ref):
 @when('the respondent goes to the history page')
 def respondent_goes_to_history_page_for_49900000002(_):
     signed_in_respondent(_)
-    time.sleep(60)
+    time.sleep(30)
     surveys_history.go_to_history_tab()
 
 

--- a/acceptance_tests/features/steps/change_response_status.py
+++ b/acceptance_tests/features/steps/change_response_status.py
@@ -63,7 +63,7 @@ def respondent_enrolled_for_ce(_, survey, period, ru_ref):
 @when('the respondent goes to the history page')
 def respondent_goes_to_history_page_for_49900000002(_):
     signed_in_respondent(_)
-    time.sleep(30)
+    time.sleep(60)
     surveys_history.go_to_history_tab()
 
 


### PR DESCRIPTION
# Motivation and Context
We had an AT failing, when it was trying to navigate to the `history tab` once a survey had been set to `completed by phone`. What was hapening was when going to the history tab, the survey hadn't had enough time to appear. 

# What has changed
Just adding a wait between signing in and checkout out history page

# How to test?
Run AT's
