### PR TITLE
Add delay to wait for file to finish being written to SFTP server

### DIFF
--- a/acceptance_tests/features/steps/notification_letter.py
+++ b/acceptance_tests/features/steps/notification_letter.py
@@ -40,7 +40,7 @@ def letter_is_received(context):
     with _get_sftp_client() as client:
         file_path = _get_path_of_latest_notification_file(client, context.start,
                                                           survey_ref='073', period='0718')
-        
+
         time.sleep(5)
 
         with client.open(file_path) as sftp_file:

--- a/acceptance_tests/features/steps/notification_letter.py
+++ b/acceptance_tests/features/steps/notification_letter.py
@@ -1,4 +1,5 @@
 import logging
+import time
 from datetime import timedelta, datetime
 
 import paramiko
@@ -39,6 +40,8 @@ def letter_is_received(context):
     with _get_sftp_client() as client:
         file_path = _get_path_of_latest_notification_file(client, context.start,
                                                           survey_ref='073', period='0718')
+        
+        time.sleep(5)
 
         with client.open(file_path) as sftp_file:
             content = str(sftp_file.read())


### PR DESCRIPTION
# Motivation and Context
We are seeing the ATs fail intermittently complaining that an IAC code can't be found in a file. On investigation, the IAC code **IS** in the file, but the acceptance test is opening the file too quickly after it's seen it, and it's still in the process of being written to.

# What has changed
Added a 5 second completely arbitrary delay to the code which is looking for new files on the SFTP server, to give Action Exporter a bit more time to finish writing to the file.

# How to test?
Run the acceptance tests multiple times. It's an intermittent failure, so it's hard to know if it's resolved the issue or not.

# Links
Trello: https://trello.com/c/tGhKAtKm/445-bug-acceptance-tests-reading-sftp-files-while-they-are-still-being-written