### PR TITLE
Make notification file test more robust

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,7 @@ wait_for_services:
 
 clean:
 	pipenv run python reset_database.py
+	pipenv run python reset_sftp_server.py
 
 setup: clean
 	./setup_data.sh ${RM_TOOLS_REPO_URL}

--- a/controllers/database_controller.py
+++ b/controllers/database_controller.py
@@ -1,4 +1,5 @@
 import logging
+import time
 
 from sqlalchemy import create_engine
 from structlog import wrap_logger
@@ -61,3 +62,40 @@ def get_iac_for_collection_exercise(collection_exercise_id, social=False):
     for row in result:
         iac = row['iac']
     return iac
+
+
+def get_all_iacs_for_collection_exercise(collection_exercise_id, social=False):
+
+    if social:
+        sample_unit_type = "H"
+    else:
+        sample_unit_type = "B"
+
+    sql_statement = "SELECT a.iac FROM casesvc.caseiacaudit a " \
+                    "INNER JOIN casesvc.case c ON a.casefk = c.casepk " \
+                    "INNER JOIN iac.iac i ON a.iac = i.code " \
+                    "INNER JOIN casesvc.casegroup g ON c.casegroupfk = g.casegrouppk " \
+                    f"WHERE c.statefk = 'ACTIONABLE' AND c.SampleUnitType = '{sample_unit_type}'" \
+                    f"AND g.collectionexerciseid = '{collection_exercise_id}' " \
+                    "AND i.active = TRUE " \
+                    "ORDER BY c.createddatetime DESC;"
+    result = execute_sql(sql_string=sql_statement)
+    iacs = []
+    for row in result:
+        iacs.append(row['iac'])
+    return iacs
+
+
+def poll_collection_exercise_until_ready_for_live_or_live(collection_exercise_id):
+
+    for _ in range(12):
+        sql = f"SELECT 1 FROM collectionexercise.collectionexercise" \
+              f" WHERE id='{collection_exercise_id}' AND statefk in ('READY_FOR_LIVE', 'LIVE')"
+        result = execute_sql(sql_string=sql)
+
+        if len(result.fetchall()) == 1:
+            return True
+
+        time.sleep(10)
+
+    return False

--- a/reset_sftp_server.py
+++ b/reset_sftp_server.py
@@ -1,0 +1,24 @@
+import paramiko
+
+from config import Config
+
+if __name__ == '__main__':
+    print('Resetting sftp server')
+    ssh = paramiko.SSHClient()
+    ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+    ssh.connect(hostname=Config.SFTP_HOST,
+                port=int(Config.SFTP_PORT),
+                username=Config.SFTP_USERNAME,
+                password=Config.SFTP_PASSWORD,
+                look_for_keys=False,
+                timeout=120)
+    sftp = ssh.open_sftp()
+
+    files = sftp.listdir(path=Config.SFTP_DIR)
+    for file in files:
+        sftp.remove(f"{Config.SFTP_DIR}/{file}")
+
+    sftp.close()
+    ssh.close()
+
+    print('Successfully reset sftp server')


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Currently only on enrolment code was getting checked, now we check
all of the expected enrolment code. 
Also the enrolment codes sometimes get written over multiple notification files, now we make sure we check all files instead of just one.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
Now checking all enrolment codes are in the notification file.
Also check all notification files for that survey ref and 
collection exercise instead of just one.

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
Ran ATs

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
