### PR TITLE
Catch FileNotFoundError

### DIFF
--- a/reset_sftp_server.py
+++ b/reset_sftp_server.py
@@ -16,7 +16,11 @@ if __name__ == '__main__':
 
     files = sftp.listdir(path=Config.SFTP_DIR)
     for file in files:
-        sftp.remove(f"{Config.SFTP_DIR}/{file}")
+        path = f"{Config.SFTP_DIR}/{file}"
+        try:
+            sftp.remove(path)
+        except FileNotFoundError:
+            print("Can't find file " + path)
 
     sftp.close()
     ssh.close()


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
When using sftp.listdir you get a list of files and directory paths.
But sftp.remove only removes files and raises FileNotFoundError for
directories.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
 Instead of letting the FileNotFoundError bubble up it is being suppressed.

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
Run ATs

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
