### PR TITLE
Use post case event endpoint instead of casegroup transition

### DIFF
--- a/acceptance_tests/features/steps/social_disable_response_status.py
+++ b/acceptance_tests/features/steps/social_disable_response_status.py
@@ -4,7 +4,7 @@ from acceptance_tests.features.pages import social_change_case_status
 from acceptance_tests.features.pages import social_search_by_postcode
 from acceptance_tests.features.pages import social_view_case_details
 from acceptance_tests.features.steps import authentication
-from controllers.case_controller import update_case_group_status
+from controllers.case_controller import post_case_event
 from controllers.iac_controller import get_iac
 
 
@@ -27,9 +27,7 @@ def sel_user_changes_case_details(context, status):
 @when('the respondent enters a UAC')
 def transition_case_to_in_progress(context):
     # Send an EQ_LAUNCH event to transition the case to IN_PROGRESS
-    update_case_group_status(context.collection_exercise_id,
-                             f"{context.address['TLA']}{context.address['reference']}",
-                             'EQ_LAUNCH')
+    post_case_event(context.case['id'], 'EQ_LAUNCH', 'Launching EQ')
 
 
 @then('they are informed that they are unable to launch the survey')

--- a/acceptance_tests/features/steps/social_survey_setup.py
+++ b/acceptance_tests/features/steps/social_survey_setup.py
@@ -1,8 +1,10 @@
 from behave import given
 
 from common.social_survey_setup import create_social_survey_cases
+from controllers.case_controller import get_case_by_iac
 
 
 @given('a social survey exists')
 def create_social_survey(context):
     context.iac = create_social_survey_cases(context)
+    context.case = get_case_by_iac(context.iac)

--- a/common/social_survey_setup.py
+++ b/common/social_survey_setup.py
@@ -4,7 +4,6 @@ from random import randint
 
 from structlog import wrap_logger
 
-from controllers.case_controller import get_case_by_iac
 from controllers.collection_exercise_controller import create_and_execute_social_collection_exercise
 from controllers.survey_controller import create_survey, create_classifiers
 

--- a/common/social_survey_setup.py
+++ b/common/social_survey_setup.py
@@ -4,6 +4,7 @@ from random import randint
 
 from structlog import wrap_logger
 
+from controllers.case_controller import get_case_by_iac
 from controllers.collection_exercise_controller import create_and_execute_social_collection_exercise
 from controllers.survey_controller import create_survey, create_classifiers
 
@@ -35,7 +36,6 @@ def create_social_survey_cases(context):
 
     user_description = 'UserDescription-' + test_unique_id
     dates = generate_collection_exercise_dates()
-
     return create_and_execute_social_collection_exercise(context, survey_id, period, user_description, dates,
                                                          short_name=survey_short_name)
 

--- a/controllers/case_controller.py
+++ b/controllers/case_controller.py
@@ -97,17 +97,6 @@ def get_case_by_party_id(party_id):
     return response.json()
 
 
-def update_case_group_status(collection_exercise_id, ru_ref, case_group_event):
-    logger.debug('Updating status', collection_exercise_id=collection_exercise_id, ru_ref=ru_ref,
-                 case_group_event=case_group_event)
-    url = f'{Config.CASE_SERVICE}/casegroups/transitions/{collection_exercise_id}/{ru_ref}'
-    response = requests.put(url, auth=Config.BASIC_AUTH, json={'event': case_group_event})
-
-    response.raise_for_status()
-    logger.debug('Successfully updated status', collection_exercise_id=collection_exercise_id, ru_ref=ru_ref,
-                 case_group_event=case_group_event)
-
-
 def get_case_iac(case_id):
     url = f'{Config.CASE_SERVICE}/cases/{case_id}'
     response = requests.get(url, auth=Config.BASIC_AUTH, params={'iac': 'true'})
@@ -116,3 +105,10 @@ def get_case_iac(case_id):
         logger.error('Failed to retrieve Iac code', status=response.status_code)
 
     return response.json()['iac']
+
+
+def get_case_by_iac(iac):
+    url = f'{Config.CASE_SERVICE}/cases/iac/{iac}'
+    response = requests.get(url, auth=Config.BASIC_AUTH)
+    response.raise_for_status()
+    return response.json()


### PR DESCRIPTION
# Motivation and Context
We are removing the `/casegroups/transitions/...` endpoint so casegroups now need to be transitioned with a case event

# What has changed
Replace calls to the casegroups transitions endpoints with case event posts

# How to test?
Acceptance tests should pass when ran with associated PR's

# Links
[Trello](https://trello.com/c/xkWvMZFk/420-use-case-event-rather-than-case-group-transition-for-change-response-status)

## Associated PR's
[response-operations-ui](https://github.com/ONSdigital/response-operations-ui/pull/250)
[response-operations-social-ui](https://github.com/ONSdigital/response-operations-social-ui/pull/17)
[rm-case-service](https://github.com/ONSdigital/rm-case-service/pull/93)