### PR TITLE
Added acceptance tests for view response status feature

### DIFF
--- a/acceptance_tests/features/steps/view_response_status.py
+++ b/acceptance_tests/features/steps/view_response_status.py
@@ -8,11 +8,11 @@ from acceptance_tests.features.pages import reporting_unit
 @then('the "{survey}" "{period}" collection exercise for ru "{ru_ref}" displays a view link')
 def assert_view_response_status_link(_, survey, period, ru_ref):
     reporting_unit.go_to(ru_ref)
-    reporting_unit.click_data_panel('Bricks')
+    reporting_unit.click_data_panel(survey)
     response_table = browser.find_by_name('tbl-ce-for-survey')
     rows = response_table.find_by_tag('tbody').find_by_tag('tr')
     for row in rows:
-        if '202001' in row.text:
+        if period in row.text:
             assert browser.is_text_present('Completed by phone View')
 
 

--- a/acceptance_tests/features/steps/view_response_status.py
+++ b/acceptance_tests/features/steps/view_response_status.py
@@ -1,33 +1,31 @@
-from behave import when, given, then
+
+from behave import when, then
 
 from acceptance_tests import browser
 from acceptance_tests.features.pages import reporting_unit
-
-RESPONSE_STATUS = browser.find_by_name('tbl-ce-status')
 
 
 @then('the "{survey}" "{period}" collection exercise for ru "{ru_ref}" displays a view link')
 def assert_view_response_status_link(_, survey, period, ru_ref):
     reporting_unit.go_to(ru_ref)
     reporting_unit.click_data_panel('Bricks')
-    view_link = '<a href="/case/49900000001/response-status?survey=Bricks&amp;period=202001">View</a>'
-    assert view_link in RESPONSE_STATUS
+    response_table = browser.find_by_name('tbl-ce-for-survey')
+    rows = response_table.find_by_tag('tbody').find_by_tag('tr')
+    for row in rows:
+        if '202001' in row.text:
+            assert browser.is_text_present('Completed by phone View')
 
 
-@when('the internal user click view the response status for "{survey}" "{period}"')
-def internal_user_click_view_response_status(_, survey, period):
-    view_link = '/case/49900000001/response-status?survey=Bricks&amp;period=202001'
-    browser.click_link_by_href(view_link)
+@when('the internal user click view the response status for the survey with correct period')
+def internal_user_click_view_response_status(_):
+    browser.click_link_by_text('View')
 
 
 @then('the internal user can view the timestamp for the completed state')
 def assert_date_and_timestamp_for_completed_stated(_):
-    date_and_time_stamp = browser.find_by_id('date-and-time')
-    assert date_and_time_stamp in RESPONSE_STATUS
+    assert browser.is_element_present_by_id('date-and-time')
 
 
 @then('the only action available is the close link')
 def assert_close_link_in_response_status(_):
-    close_link = '<a href="http://localhost:8085/reporting-units/49900000001?survey=Bricks&amp;period=202001" ' \
-                 'onclick="history.back(); return false;" class="u-d-b u-mt-s">Close</a>'
-    assert close_link in RESPONSE_STATUS
+    assert browser.is_text_present('Close')

--- a/acceptance_tests/features/steps/view_response_status.py
+++ b/acceptance_tests/features/steps/view_response_status.py
@@ -1,0 +1,33 @@
+from behave import when, given, then
+
+from acceptance_tests import browser
+from acceptance_tests.features.pages import reporting_unit
+
+RESPONSE_STATUS = browser.find_by_name('tbl-ce-status')
+
+
+@then('the "{survey}" "{period}" collection exercise for ru "{ru_ref}" displays a view link')
+def assert_view_response_status_link(_, survey, period, ru_ref):
+    reporting_unit.go_to(ru_ref)
+    reporting_unit.click_data_panel('Bricks')
+    view_link = '<a href="/case/49900000001/response-status?survey=Bricks&amp;period=202001">View</a>'
+    assert view_link in RESPONSE_STATUS
+
+
+@when('the internal user click view the response status for "{survey}" "{period}"')
+def internal_user_click_view_response_status(_, survey, period):
+    view_link = '/case/49900000001/response-status?survey=Bricks&amp;period=202001'
+    browser.click_link_by_href(view_link)
+
+
+@then('the internal user can view the timestamp for the completed state')
+def assert_date_and_timestamp_for_completed_stated(_):
+    date_and_time_stamp = browser.find_by_id('date-and-time')
+    assert date_and_time_stamp in RESPONSE_STATUS
+
+
+@then('the only action available is the close link')
+def assert_close_link_in_response_status(_):
+    close_link = '<a href="http://localhost:8085/reporting-units/49900000001?survey=Bricks&amp;period=202001" ' \
+                 'onclick="history.back(); return false;" class="u-d-b u-mt-s">Close</a>'
+    assert close_link in RESPONSE_STATUS

--- a/acceptance_tests/features/view_response_status.feature
+++ b/acceptance_tests/features/view_response_status.feature
@@ -1,0 +1,23 @@
+Feature: View response status
+  As an internal user
+  I need to view the case response status for an RU for a specific CE for a specific survey when completed
+  So that I can view the date and timestamp of the completed state
+
+  Background: Internal user is already signed in and a respondent is enrolled on a new collection exercise
+    Given the internal user is already signed in
+    And the "Bricks" "202001" collection exercise has been executed
+
+  @us208
+  Scenario: Internal user can see the view link for response status Completed by phone
+    Given the internal user is on the reporting unit page for ru ref "49900000001"
+    And the "Bricks" "202001" collection exercise for ru "49900000001" is in the "Not started" status
+    When the internal user changes the response status for "Bricks" "202001" to "Completed by phone"
+    Then the "Bricks" "202001" collection exercise for ru "49900000001" displays a view link
+
+  @us208
+  Scenario: Internal user can view the date and timestamp for a completed survey in the response status panel
+    Given the internal user is on the reporting unit page for ru ref "49900000001"
+    And the "Bricks" "202001" collection exercise for ru "49900000001" is in the "Completed by phone" status
+    When the internal user click view the response status for "Bricks" "202001"
+    Then the internal user can view the timestamp for the completed state
+    And the only action available is the close link

--- a/acceptance_tests/features/view_response_status.feature
+++ b/acceptance_tests/features/view_response_status.feature
@@ -5,7 +5,6 @@ Feature: View response status
 
   Background: Internal user is already signed in and a respondent is enrolled on a new collection exercise
     Given the internal user is already signed in
-    And the "Bricks" "202001" collection exercise has been executed
 
   @us208
   Scenario: Internal user can see the view link for response status Completed by phone
@@ -18,6 +17,6 @@ Feature: View response status
   Scenario: Internal user can view the date and timestamp for a completed survey in the response status panel
     Given the internal user is on the reporting unit page for ru ref "49900000001"
     And the "Bricks" "202001" collection exercise for ru "49900000001" is in the "Completed by phone" status
-    When the internal user click view the response status for "Bricks" "202001"
+    When the internal user click view the response status for the survey with correct period
     Then the internal user can view the timestamp for the completed state
     And the only action available is the close link


### PR DESCRIPTION
# Motivation and Context
New functionality added in to ROps RU page to view a response status when it is in a completed state. These AT's have come off the user story.

# What has changed
New feature for viewing response status

# How to test?
Run AT's against the branch in ROps, and review code standard.

# Links
[Trello Card](https://trello.com/c/mr2EipGk/287-us208-int-display-date-and-time-stamp-alongside-rus-ce-response-status-m)
[ROps PR](https://github.com/ONSdigital/response-operations-ui/pull/257)
