### PR TITLE
Create separate UAA user accounts and renamed fixtures

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -21,6 +21,7 @@ paramiko = "*"
 "psycopg2" = "*"
 pytz = "*"
 tzlocal = "*"
+psutil = "*"
 
 [requires]
 python_version = "3.6"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "605c668acbd80c319931cbd5d3179cdc7a39eaa7baf3cce9f5412d677b912e00"
+            "sha256": "989291ab7f30894d768b1fbc05ba78cdbc3de7e9c899497f393723c6dc60bb13"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -131,27 +131,27 @@
         },
         "cryptography": {
             "hashes": [
-                "sha256:02602e1672b62e803e08617ec286041cc453e8d43f093a5f4162095506bc0beb",
-                "sha256:10b48e848e1edb93c1d3b797c83c72b4c387ab0eb4330aaa26da8049a6cbede0",
-                "sha256:17db09db9d7c5de130023657be42689d1a5f60502a14f6f745f6f65a6b8195c0",
-                "sha256:227da3a896df1106b1a69b1e319dce218fa04395e8cc78be7e31ca94c21254bc",
-                "sha256:2cbaa03ac677db6c821dac3f4cdfd1461a32d0615847eedbb0df54bb7802e1f7",
-                "sha256:31db8febfc768e4b4bd826750a70c79c99ea423f4697d1dab764eb9f9f849519",
-                "sha256:4a510d268e55e2e067715d728e4ca6cd26a8e9f1f3d174faf88e6f2cb6b6c395",
-                "sha256:6a88d9004310a198c474d8a822ee96a6dd6c01efe66facdf17cb692512ae5bc0",
-                "sha256:76936ec70a9b72eb8c58314c38c55a0336a2b36de0c7ee8fb874a4547cadbd39",
-                "sha256:7e3b4aecc4040928efa8a7cdaf074e868af32c58ffc9bb77e7bf2c1a16783286",
-                "sha256:8168bcb08403ef144ff1fb880d416f49e2728101d02aaadfe9645883222c0aa5",
-                "sha256:8229ceb79a1792823d87779959184a1bf95768e9248c93ae9f97c7a2f60376a1",
-                "sha256:8a19e9f2fe69f6a44a5c156968d9fc8df56d09798d0c6a34ccc373bb186cee86",
-                "sha256:8d10113ca826a4c29d5b85b2c4e045ffa8bad74fb525ee0eceb1d38d4c70dfd6",
-                "sha256:be495b8ec5a939a7605274b6e59fbc35e76f5ad814ae010eb679529671c9e119",
-                "sha256:dc2d3f3b1548f4d11786616cf0f4415e25b0fbecb8a1d2cd8c07568f13fdde38",
-                "sha256:e4aecdd9d5a3d06c337894c9a6e2961898d3f64fe54ca920a72234a3de0f9cb3",
-                "sha256:e79ab4485b99eacb2166f3212218dd858258f374855e1568f728462b0e6ee0d9",
-                "sha256:f995d3667301e1754c57b04e0bae6f0fa9d710697a9f8d6712e8cca02550910f"
+                "sha256:02915ee546b42ce513e8167140e9937fc4c81a06a82216e086ccce51f347948a",
+                "sha256:03cc8bc5a69ae3d44acf1a03facdb7c10a94c67907862c563e10efe72b737977",
+                "sha256:07f76bde6815c55195f3b3812d35769cc7c765144c0bb71ae45e02535d078591",
+                "sha256:13eac1c477b9af7e9a9024369468d08aead6ad78ed599d163ad046684474364b",
+                "sha256:179bfb585c5efc87ae0e665770e4896727b92dbc1f810c761b1ebf8363e2fec8",
+                "sha256:414af0ba308e74c1f8bc5b11befc86cb66b10be8959547786f64258830d2096f",
+                "sha256:41a1ca14f255df8c44dd22c6006441d631d1589104045ec7263cc47e9772f41a",
+                "sha256:54947eb98bc4eef99ddf49f45d2694ea5a3929ab3edc9806ad01967368594d82",
+                "sha256:5bac7a2abda07d0c3c8429210349bb54149ad8940dc7bcffedcd56519b410a3c",
+                "sha256:7f41af8c586bed9f59cfe8832d818b3b75c860d7025da9cd2db76875a72ff785",
+                "sha256:8004fae1b3cb2dbd90a011ad972e49a7e78a871b89c70cc7213cf4ebd2532bcb",
+                "sha256:8e0eccadc3b465e12c50a5b8fb4d39cf401b44d7bb9936c70fddb5e5aaf740d5",
+                "sha256:95b4741722269cfdc134fec23b7ae6503ee2aea83d0924cfee6d6ec54cd42d8e",
+                "sha256:a06f5aa6d7a94531dfe82eb2972e669258c452fe9cf88f76116610de4c789785",
+                "sha256:b0833d27c7eb536bc27323a1e8e22cb39ebac78c4ef3be0167ba40f447344808",
+                "sha256:b72dec675bc59a01edc96616cd48ec465b714481caa0938c8bbca5d18f17d5df",
+                "sha256:c800ddc23b5206ce025f23225fdde89cdc0e64016ad914d5be32d1f602ce9495",
+                "sha256:c980c8c313a5e014ae12e2245e89e7b30427e5a98cbb88afe478ecae85f3abaa",
+                "sha256:e85b410885addaeb31a867eabcefc9ef4a7e904ad45eac9e60a763a54b244626"
             ],
-            "version": "==2.3.1"
+            "version": "==2.4.1"
         },
         "idna": {
             "hashes": [
@@ -198,77 +198,92 @@
             ],
             "version": "==0.4.2"
         },
-        "psycopg2": {
+        "psutil": {
             "hashes": [
-                "sha256:0b9e48a1c1505699a64ac58815ca99104aacace8321e455072cee4f7fe7b2698",
-                "sha256:0f4c784e1b5a320efb434c66a50b8dd7e30a7dc047e8f45c0a8d2694bfe72781",
-                "sha256:0fdbaa32c9eb09ef09d425dc154628fca6fa69d2f7c1a33f889abb7e0efb3909",
-                "sha256:11fbf688d5c953c0a5ba625cc42dea9aeb2321942c7c5ed9341a68f865dc8cb1",
-                "sha256:19eaac4eb25ab078bd0f28304a0cb08702d120caadfe76bb1e6846ed1f68635e",
-                "sha256:3232ec1a3bf4dba97fbf9b03ce12e4b6c1d01ea3c85773903a67ced725728232",
-                "sha256:36f8f9c216fcca048006f6dd60e4d3e6f406afde26cfb99e063f137070139eaf",
-                "sha256:59c1a0e4f9abe970062ed35d0720935197800a7ef7a62b3a9e3a70588d9ca40b",
-                "sha256:6506c5ff88750948c28d41852c09c5d2a49f51f28c6d90cbf1b6808e18c64e88",
-                "sha256:6bc3e68ee16f571681b8c0b6d5c0a77bef3c589012352b3f0cf5520e674e9d01",
-                "sha256:6dbbd7aabbc861eec6b910522534894d9dbb507d5819bc982032c3ea2e974f51",
-                "sha256:6e737915de826650d1a5f7ff4ac6cf888a26f021a647390ca7bafdba0e85462b",
-                "sha256:6ed9b2cfe85abc720e8943c1808eeffd41daa73e18b7c1e1a228b0b91f768ccc",
-                "sha256:711ec617ba453fdfc66616db2520db3a6d9a891e3bf62ef9aba4c95bb4e61230",
-                "sha256:844dacdf7530c5c612718cf12bc001f59b2d9329d35b495f1ff25045161aa6af",
-                "sha256:86b52e146da13c896e50c5a3341a9448151f1092b1a4153e425d1e8b62fec508",
-                "sha256:985c06c2a0f227131733ae58d6a541a5bc8b665e7305494782bebdb74202b793",
-                "sha256:a86dfe45f4f9c55b1a2312ff20a59b30da8d39c0e8821d00018372a2a177098f",
-                "sha256:aa3cd07f7f7e3183b63d48300666f920828a9dbd7d7ec53d450df2c4953687a9",
-                "sha256:b1964ed645ef8317806d615d9ff006c0dadc09dfc54b99ae67f9ba7a1ec9d5d2",
-                "sha256:b2abbff9e4141484bb89b96eb8eae186d77bc6d5ffbec6b01783ee5c3c467351",
-                "sha256:cc33c3a90492e21713260095f02b12bee02b8d1f2c03a221d763ce04fa90e2e9",
-                "sha256:d7de3bf0986d777807611c36e809b77a13bf1888f5c8db0ebf24b47a52d10726",
-                "sha256:db5e3c52576cc5b93a959a03ccc3b02cb8f0af1fbbdc80645f7a215f0b864f3a",
-                "sha256:e168aa795ffbb11379c942cf95bf813c7db9aa55538eb61de8c6815e092416f5",
-                "sha256:e9ca911f8e2d3117e5241d5fa9aaa991cb22fb0792627eeada47425d706b5ec8",
-                "sha256:eccf962d41ca46e6326b97c8fe0a6687b58dfc1a5f6540ed071ff1474cea749e",
-                "sha256:efa19deae6b9e504a74347fe5e25c2cb9343766c489c2ae921b05f37338b18d1",
-                "sha256:f4b0460a21f784abe17b496f66e74157a6c36116fa86da8bf6aa028b9e8ad5fe",
-                "sha256:f93d508ca64d924d478fb11e272e09524698f0c581d9032e68958cfbdd41faef"
+                "sha256:1c19957883e0b93d081d41687089ad630e370e26dc49fd9df6951d6c891c4736",
+                "sha256:1c71b9716790e202a00ab0931a6d1e25db1aa1198bcacaea2f5329f75d257fff",
+                "sha256:3b7a4daf4223dae171a67a89314ac5ca0738e94064a78d99cfd751c55d05f315",
+                "sha256:3e19be3441134445347af3767fa7770137d472a484070840eee6653b94ac5576",
+                "sha256:6e265c8f3da00b015d24b842bfeb111f856b13d24f2c57036582568dc650d6c3",
+                "sha256:809c9cef0402e3e48b5a1dddc390a8a6ff58b15362ea5714494073fa46c3d293",
+                "sha256:b4d1b735bf5b120813f4c89db8ac22d89162c558cbd7fdd298866125fe906219",
+                "sha256:bbffac64cfd01c6bcf90eb1bedc6c80501c4dae8aef4ad6d6dd49f8f05f6fc5a",
+                "sha256:bfcea4f189177b2d2ce4a34b03c4ac32c5b4c22e21f5b093d9d315e6e253cd81"
             ],
             "index": "pypi",
-            "version": "==2.7.5"
+            "version": "==5.4.8"
+        },
+        "psycopg2": {
+            "hashes": [
+                "sha256:10e391687b171878181e71736d0effe3772314a339d9ae30995ec8171a0c834e",
+                "sha256:1283f9d45e458c2dcb15ba89367923563f90ef636fe78ee22df75183484a0237",
+                "sha256:1a9c32e4d140bea225f9821d993b2e53c913e717ea97b851246aa9b300095d8f",
+                "sha256:1be6f2438d2b71fec7b07c3c0949dd321b04349c382907ea76b36120edec8300",
+                "sha256:20ca6f29e118b8dd7133e8708b3fba2881e70a4e0841f874ed23985b7201a076",
+                "sha256:227c115b3c1f65d61385e51ac690b91b584640aefb45bffacd4bd33d02ed7221",
+                "sha256:27959abe64ca1fc6d8cd11a71a1f421d8287831a3262bd4cacd43bbf43cc3c82",
+                "sha256:2b2daf1fe30a58300542aea679fd87d1e1c2afd36e7644837b7954fa2dbacb92",
+                "sha256:36e51a51f295fdf67bcf05e7b1877011a6b39e6622b0013fe31c5025241873a3",
+                "sha256:3992b9b914f2eb77dc07e8045d2ca979e491612808bc5c7cd68f307469acf9f6",
+                "sha256:39a11de2335ad45ececed43ab851d36a4c52843d756471b940804f301792781e",
+                "sha256:3c2afe9ef0d1649005e3ccf93c1aaccd6f8ee379530e763d3b3b77f406b7c0ae",
+                "sha256:3fb18e0e52807fe3a300dc1b5421aa492d5e759550918f597d61863419482535",
+                "sha256:55eab94de96ee9702f23283e9c8b03cfdb0001e2b14d5d2e1bd5ff8114b96b9f",
+                "sha256:7e95c0ab7e7e6e452586f35d4d8966b1e924c8dd2c23977e3ea4968770ff1d26",
+                "sha256:7f47514dbddf604f196fcfe5da955537f04691bef8124aff5632316a78d992b7",
+                "sha256:8345370356bb4bddf93acbcfd0357163dd6b09471937adcfb38a2fbb49bdce53",
+                "sha256:8bc6ecb220c0b88d3742042013129c817c44459795c97e9ce1bca70a3f37a53b",
+                "sha256:8df623f248be15d1725faf5f333791678775047f12f17a90d29b5d22573f5cdc",
+                "sha256:9645f1305e4268cc0fc88c823cd6c91de27c003e183c233a6a230e5e963039ee",
+                "sha256:a68719ed5be8373dd72c9e45d55f7a202285e05a2e392eaa8872a67ea47d7d20",
+                "sha256:aca0edf062ec09e954fdf0cc93d3a872362701210983a1442549e703aedec25d",
+                "sha256:b0dd2114d93d8f424bb8ae76e0dc540f104b70ca9163172c05e7700b1459d4c9",
+                "sha256:b2c09359d6802279efb9efb3f91a9c94567151baee95175f9b637ea628f35244",
+                "sha256:ca7bc37b1efb7cc25271bf10f398462ed975d95259af1406d38fcb268466e34f",
+                "sha256:e64235d9013ebf6319cb9654e08f5066112c34d8c4cc41186254ab9c3d6d5b9b",
+                "sha256:ec9be679c0065667503851141c31fa699e1cc69ded3ba8e5d3673dd5a6eb1370",
+                "sha256:eca00d0f91fcb44d88b12f1fd16ad138e38fa07debb79587e2b7ff1fe80d72b9",
+                "sha256:f256e807b8b2b45b6af60d7f2bb5194aab2f4acc861241c4d8ef942a55f5030d",
+                "sha256:fce7612a3bd6a7ba95799f88285653bf130bd7ca066b52674d5f850108b2aec0"
+            ],
+            "index": "pypi",
+            "version": "==2.7.6.1"
         },
         "psycopg2-binary": {
             "hashes": [
-                "sha256:04afb59bbbd2eab3148e6816beddc74348078b8c02a1113ea7f7822f5be4afe3",
-                "sha256:098b18f4d8857a8f9b206d1dc54db56c2255d5d26458917e7bcad61ebfe4338f",
-                "sha256:0bf855d4a7083e20ead961fda4923887094eaeace0ab2d76eb4aa300f4bbf5bd",
-                "sha256:197dda3ffd02057820be83fe4d84529ea70bf39a9a4daee1d20ffc74eb3d042e",
-                "sha256:278ef63afb4b3d842b4609f2c05ffbfb76795cf6a184deeb8707cd5ed3c981a5",
-                "sha256:3cbf8c4fc8f22f0817220891cf405831559f4d4c12c4f73913730a2ea6c47a47",
-                "sha256:4305aed922c4d9d6163ab3a41d80b5a1cfab54917467da8168552c42cad84d32",
-                "sha256:47ee296f704fb8b2a616dec691cdcfd5fa0f11943955e88faa98cbd1dc3b3e3d",
-                "sha256:4a0e38cb30457e70580903367161173d4a7d1381eb2f2cfe4e69b7806623f484",
-                "sha256:4d6c294c6638a71cafb82a37f182f24321f1163b08b5d5ca076e11fe838a3086",
-                "sha256:4f3233c366500730f839f92833194fd8f9a5c4529c8cd8040aa162c3740de8e5",
-                "sha256:5221f5a3f4ca2ddf0d58e8b8a32ca50948be9a43351fda797eb4e72d7a7aa34d",
-                "sha256:5c6ca0b507540a11eaf9e77dee4f07c131c2ec80ca0cffa146671bf690bc1c02",
-                "sha256:789bd89d71d704db2b3d5e67d6d518b158985d791d3b2dec5ab85457cfc9677b",
-                "sha256:7b94d29239efeaa6a967f3b5971bd0518d2a24edd1511edbf4a2c8b815220d07",
-                "sha256:89bc65ef3301c74cf32db25334421ea6adbe8f65601ea45dcaaf095abed910bb",
-                "sha256:89d6d3a549f405c20c9ae4dc94d7ed2de2fa77427a470674490a622070732e62",
-                "sha256:97521704ac7127d7d8ba22877da3c7bf4a40366587d238ec679ff38e33177498",
-                "sha256:a395b62d5f44ff6f633231abe568e2203b8fabf9797cd6386aa92497df912d9a",
-                "sha256:a6d32c37f714c3f34158f3fa659f3a8f2658d5f53c4297d45579b9677cc4d852",
-                "sha256:a89ee5c26f72f2d0d74b991ce49e42ddeb4ac0dc2d8c06a0f2770a1ab48f4fe0",
-                "sha256:b4c8b0ef3608e59317bfc501df84a61e48b5445d45f24d0391a24802de5f2d84",
-                "sha256:b5fcf07140219a1f71e18486b8dc28e2e1b76a441c19374805c617aa6d9a9d55",
-                "sha256:b86f527f00956ecebad6ab3bb30e3a75fedf1160a8716978dd8ce7adddedd86f",
-                "sha256:be4c4aa22ba22f70de36c98b06480e2f1697972d49eb20d525f400d204a6d272",
-                "sha256:c2ac7aa1a144d4e0e613ac7286dae85671e99fe7a1353954d4905629c36b811c",
-                "sha256:de26ef4787b5e778e8223913a3e50368b44e7480f83c76df1f51d23bd21cea16",
-                "sha256:e70ebcfc5372dc7b699c0110454fc4263967f30c55454397e5769eb72c0eb0ce",
-                "sha256:eadbd32b6bc48b67b0457fccc94c86f7ccc8178ab839f684eb285bb592dc143e",
-                "sha256:ecbc6dfff6db06b8b72ae8a2f25ff20fbdcb83cb543811a08f7cb555042aa729"
+                "sha256:036bcb198a7cc4ce0fe43344f8c2c9a8155aefa411633f426c8c6ed58a6c0426",
+                "sha256:1d770fcc02cdf628aebac7404d56b28a7e9ebec8cfc0e63260bd54d6edfa16d4",
+                "sha256:1fdc6f369dcf229de6c873522d54336af598b9470ccd5300e2f58ee506f5ca13",
+                "sha256:21f9ddc0ff6e07f7d7b6b484eb9da2c03bc9931dd13e36796b111d631f7135a3",
+                "sha256:247873cda726f7956f745a3e03158b00de79c4abea8776dc2f611d5ba368d72d",
+                "sha256:3aa31c42f29f1da6f4fd41433ad15052d5ff045f2214002e027a321f79d64e2c",
+                "sha256:475f694f87dbc619010b26de7d0fc575a4accf503f2200885cc21f526bffe2ad",
+                "sha256:4b5e332a24bf6e2fda1f51ca2a57ae1083352293a08eeea1fa1112dc7dd542d1",
+                "sha256:570d521660574aca40be7b4d532dfb6f156aad7b16b5ed62d1534f64f1ef72d8",
+                "sha256:59072de7def0690dd13112d2bdb453e20570a97297070f876fbbb7cbc1c26b05",
+                "sha256:5f0b658989e918ef187f8a08db0420528126f2c7da182a7b9f8bf7f85144d4e4",
+                "sha256:649199c84a966917d86cdc2046e03d536763576c0b2a756059ae0b3a9656bc20",
+                "sha256:6645fc9b4705ae8fbf1ef7674f416f89ae1559deec810f6dd15197dfa52893da",
+                "sha256:6872dd54d4e398d781efe8fe2e2d7eafe4450d61b5c4898aced7610109a6df75",
+                "sha256:6ce34fbc251fc0d691c8d131250ba6f42fd2b28ef28558d528ba8c558cb28804",
+                "sha256:73920d167a0a4d1006f5f3b9a3efce6f0e5e883a99599d38206d43f27697df00",
+                "sha256:8a671732b87ae423e34b51139628123bc0306c2cb85c226e71b28d3d57d7e42a",
+                "sha256:8d517e8fda2efebca27c2018e14c90ed7dc3f04d7098b3da2912e62a1a5585fe",
+                "sha256:9475a008eb7279e20d400c76471843c321b46acacc7ee3de0b47233a1e3fa2cf",
+                "sha256:96947b8cd7b3148fb0e6549fcb31258a736595d6f2a599f8cd450e9a80a14781",
+                "sha256:abf229f24daa93f67ac53e2e17c8798a71a01711eb9fcdd029abba8637164338",
+                "sha256:b1ab012f276df584beb74f81acb63905762c25803ece647016613c3d6ad4e432",
+                "sha256:b22b33f6f0071fe57cb4e9158f353c88d41e739a3ec0d76f7b704539e7076427",
+                "sha256:b3b2d53274858e50ad2ffdd6d97ce1d014e1e530f82ec8b307edd5d4c921badf",
+                "sha256:bab26a729befc7b9fab9ded1bba9c51b785188b79f8a2796ba03e7e734269e2e",
+                "sha256:daa1a593629aa49f506eddc9d23dc7f89b35693b90e1fbcd4480182d1203ea90",
+                "sha256:dd111280ce40e89fd17b19c1269fd1b74a30fce9d44a550840e86edb33924eb8",
+                "sha256:e0b86084f1e2e78c451994410de756deba206884d6bed68d5a3d7f39ff5fea1d",
+                "sha256:eb86520753560a7e89639500e2a254bb6f683342af598088cb72c73edcad21e6",
+                "sha256:ff18c5c40a38d41811c23e2480615425c97ea81fd7e9118b8b899c512d97c737"
             ],
             "index": "pypi",
-            "version": "==2.7.5"
+            "version": "==2.7.6.1"
         },
         "pyasn1": {
             "hashes": [
@@ -325,11 +340,11 @@
         },
         "requests": {
             "hashes": [
-                "sha256:99dcfdaaeb17caf6e526f32b6a7b780461512ab3f1d992187801694cba42770c",
-                "sha256:a84b8c9ab6239b578f22d1c21d51b696dcfe004032bb80ea832398d6909d7279"
+                "sha256:65b3a120e4329e33c9889db89c80976c5272f56ea92d3e74da8a463992e3ff54",
+                "sha256:ea881206e59f41dbd0bd445437d792e43906703fff75ca8ff43ccdb11f33f263"
             ],
             "index": "pypi",
-            "version": "==2.20.0"
+            "version": "==2.20.1"
         },
         "retrying": {
             "hashes": [
@@ -355,18 +370,18 @@
         },
         "splinter": {
             "hashes": [
-                "sha256:08c6ed2209ce0520c2f898ad30822ba8f52ed9226bda10c0253c5ea9fe418146",
-                "sha256:c8442149e03b0e4c3cf721c4dc1fb00feb1faf52872f85921e07b0cbde467e93"
+                "sha256:2d9f370536e6c1607824f5538e0bff9808bc02f086b07622b3790424dd3daff4",
+                "sha256:5d9913bddb6030979c18d6801578813b02bbf8a03b43fb057f093228ed876d62"
             ],
             "index": "pypi",
-            "version": "==0.9.0"
+            "version": "==0.10.0"
         },
         "sqlalchemy": {
             "hashes": [
-                "sha256:84412de3794acee05630e7788f25e80e81f78eb4837e7b71d0499129f660486a"
+                "sha256:9de7c7dabcf06319becdb7e15099c44e5e34ba7062f9ba10bc00e562f5db3d04"
             ],
             "index": "pypi",
-            "version": "==1.2.13"
+            "version": "==1.2.14"
         },
         "structlog": {
             "hashes": [
@@ -393,10 +408,10 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:41c3db2fc01e5b907288010dec72f9d0a74e37d6994e6eb56849f59fea2265ae",
-                "sha256:8819bba37a02d143296a4d032373c4dd4aca11f6d4c9973335ca75f9c8475f59"
+                "sha256:61bf29cada3fc2fbefad4fdf059ea4bd1b4a86d2b6d15e1c7c0b582b9752fe39",
+                "sha256:de9529817c93f27c8ccbfead6985011db27bd0ddfcdb2d86f3f663385c6a9c22"
             ],
-            "version": "==1.24"
+            "version": "==1.24.1"
         }
     }
 }

--- a/acceptance_tests/features/add_a_survey.feature
+++ b/acceptance_tests/features/add_a_survey.feature
@@ -8,40 +8,40 @@ Feature: Add a survey
   Background: User already logged in
     Given the respondent is signed into their account
 
-  @fixture.setup.data.unenrolled.respondent
+  @fixture.setup.data.with.unenrolled.respondent.user
   @us334-addSurvey_s01
   Scenario: Select to add new survey
     When access to do list in my surveys
     Then they are able to add a new survey
 
-  @fixture.setup.data.unenrolled.respondent
+  @fixture.setup.data.with.unenrolled.respondent.user
   @us334-addSurvey_s02
   Scenario: Enter the enrolment code
     When they add a new survey
     Then they are able to enter an enrolment code
 
-  @fixture.setup.data.unenrolled.respondent
+  @fixture.setup.data.with.unenrolled.respondent.user
   @us334-addSurvey_s03
   Scenario: View survey & organisation that they are enrolling for
     Given selects to add a new survey
     When they enter a valid enrolment code
     Then they are to be presented with the survey and organisation that they are enrolling for
 
-  @fixture.setup.data.unenrolled.respondent
+  @fixture.setup.data.with.unenrolled.respondent.user
   @us334-addSurvey_s04
   Scenario: Invalid entry of an enrolment code
     Given selects to add a new survey
     When they enter an invalid enrolment code
     Then they are to be notified
 
-  @fixture.setup.data.unenrolled.respondent.generate.new.iac.collection.exercise.live
+  @fixture.setup.data.with.unenrolled.respondent.user.and.new.iac.and.collection.exercise.to.live
   @us334-addSurvey_s05, @enrolment, @smoke
   Scenario: View new survey in my surveys
     Given the user has entered a valid enrolment code
     When they continue and confirm that the organisation and survey that they are enrolling for is correct
     Then the new survey is to be listed in My Surveys and confirmation is presented to the user
 
-  @fixture.setup.data.unenrolled.respondent
+  @fixture.setup.data.with.unenrolled.respondent.user
   @us334-addSurvey_s06
   Scenario: User can cancel at any point
     Given the user has entered a valid enrolment code

--- a/acceptance_tests/features/breadcrumb_navigation.feature
+++ b/acceptance_tests/features/breadcrumb_navigation.feature
@@ -8,20 +8,20 @@ Feature: Breadcrumb Navigation
   Background: Internal user is already signed in
     Given the internal user is already signed in
 
-  @fixture.setup.data.with.response.user
+  @fixture.setup.data.with.internal.user
   Scenario: User navigates to the surveys page from collection exercise
     Given a collection exercise has been created
     When the internal user navigates to the collection exercise details page
     And the user clicks the survey breadcrumb link
     Then the user is taken to the surveys page
 
-  @fixture.setup.with.response.user
+  @fixture.setup.with.internal.user
   Scenario: User navigates to the homepage
     Given the user accesses the system
     When the internal user navigates to the home page
     Then the user does not see a breadcrumbs trail
 
-  @fixture.setup.data.with.response.user
+  @fixture.setup.data.with.internal.user
   Scenario: User can tell which page they are on in the hierarchical structure
     Given a collection exercise has been created
     When the internal user navigates to the collection exercise details page

--- a/acceptance_tests/features/breadcrumb_navigation.feature
+++ b/acceptance_tests/features/breadcrumb_navigation.feature
@@ -8,19 +8,20 @@ Feature: Breadcrumb Navigation
   Background: Internal user is already signed in
     Given the internal user is already signed in
 
-  @fixture.setup.data.default
+  @fixture.setup.data.with.response.user
   Scenario: User navigates to the surveys page from collection exercise
     Given a collection exercise has been created
     When the internal user navigates to the collection exercise details page
     And the user clicks the survey breadcrumb link
     Then the user is taken to the surveys page
 
+  @fixture.setup.with.response.user
   Scenario: User navigates to the homepage
     Given the user accesses the system
     When the internal user navigates to the home page
     Then the user does not see a breadcrumbs trail
 
-  @fixture.setup.data.default
+  @fixture.setup.data.with.response.user
   Scenario: User can tell which page they are on in the hierarchical structure
     Given a collection exercise has been created
     When the internal user navigates to the collection exercise details page

--- a/acceptance_tests/features/change_response_status.feature
+++ b/acceptance_tests/features/change_response_status.feature
@@ -9,7 +9,7 @@ Feature: Change response status
     Given the internal user is already signed in
 
   @us050_s01
-  @fixture.setup.data.enrolled.respondent
+  @fixture.setup.data.with.enrolled.respondent.user.and.response.user
   Scenario: Internal user can change the response status to Completed by phone
     Given the internal user is on the reporting unit page
     And the collection exercise is in the "Not started" status
@@ -17,7 +17,7 @@ Feature: Change response status
     Then the collection exercise is in the "Completed by phone" status
 
   @us050_s02
-  @fixture.setup.data.enrolled.respondent
+  @fixture.setup.data.with.enrolled.respondent.user.and.response.user
   Scenario: Internal user can change the response status to No Longer Required
     Given the internal user is on the reporting unit page
     And the collection exercise is in the "Not started" status
@@ -25,7 +25,7 @@ Feature: Change response status
     Then the collection exercise is in the "No longer required" status
 
   @us050_s03
-  @fixture.setup.data.enrolled.respondent.generate.new.iac.collection.exercise.live
+  @fixture.setup.data.with.enrolled.respondent.user.and.response.user.and.new.iac.and.collection.exercise.to.live
   Scenario: Respondent can view response status change
     Given the respondent has had their response status changed to Completed by phone
     When the respondent goes to the history page

--- a/acceptance_tests/features/change_response_status.feature
+++ b/acceptance_tests/features/change_response_status.feature
@@ -9,7 +9,7 @@ Feature: Change response status
     Given the internal user is already signed in
 
   @us050_s01
-  @fixture.setup.data.with.enrolled.respondent.user.and.response.user
+  @fixture.setup.data.with.enrolled.respondent.user.and.internal.user
   Scenario: Internal user can change the response status to Completed by phone
     Given the internal user is on the reporting unit page
     And the collection exercise is in the "Not started" status
@@ -17,7 +17,7 @@ Feature: Change response status
     Then the collection exercise is in the "Completed by phone" status
 
   @us050_s02
-  @fixture.setup.data.with.enrolled.respondent.user.and.response.user
+  @fixture.setup.data.with.enrolled.respondent.user.and.internal.user
   Scenario: Internal user can change the response status to No Longer Required
     Given the internal user is on the reporting unit page
     And the collection exercise is in the "Not started" status
@@ -25,7 +25,7 @@ Feature: Change response status
     Then the collection exercise is in the "No longer required" status
 
   @us050_s03
-  @fixture.setup.data.with.enrolled.respondent.user.and.response.user.and.new.iac.and.collection.exercise.to.live
+  @fixture.setup.data.with.enrolled.respondent.user.and.internal.user.and.new.iac.and.collection.exercise.to.live
   Scenario: Respondent can view response status change
     Given the respondent has had their response status changed to Completed by phone
     When the respondent goes to the history page

--- a/acceptance_tests/features/display_unused_enrolment_code.feature
+++ b/acceptance_tests/features/display_unused_enrolment_code.feature
@@ -1,6 +1,6 @@
 @business
 @standalone
-@fixture.setup.data.with.response.user
+@fixture.setup.data.with.internal.user
 Feature: Display enrolment code
   As an internal user
   I need to display unused code for a RU for a specific survey

--- a/acceptance_tests/features/display_unused_enrolment_code.feature
+++ b/acceptance_tests/features/display_unused_enrolment_code.feature
@@ -1,6 +1,6 @@
 @business
 @standalone
-@fixture.setup.data.default
+@fixture.setup.data.with.response.user
 Feature: Display enrolment code
   As an internal user
   I need to display unused code for a RU for a specific survey

--- a/acceptance_tests/features/edit_respondent_details.feature
+++ b/acceptance_tests/features/edit_respondent_details.feature
@@ -7,14 +7,14 @@ Feature: As an internal user
     Given the internal user is already signed in
 
   @us057-s01
-  @fixture.setup.data.enrolled.respondent
+  @fixture.setup.data.with.enrolled.respondent.user.and.response.user
   Scenario: The internal user is able to change a respondents first name, last name and contact number
     Given the internal user has found the respondents details
     When they choose to change the name of a respondent
     Then the respondent account details become editable
 
   @us057-s02
-  @fixture.setup.data.enrolled.respondent
+  @fixture.setup.data.with.enrolled.respondent.user.and.response.user
   Scenario: All fields are required to be populated
     Given the internal user chooses to change account details
     When they remove the old contact number
@@ -22,7 +22,7 @@ Feature: As an internal user
     Then the changes will not be saved and they are informed that all fields are required
 
   @us057-s03
-  @fixture.setup.data.enrolled.respondent
+  @fixture.setup.data.with.enrolled.respondent.user.and.response.user
   Scenario: The internal user is able to save any changes made to the account details
     Given the internal user chooses to change account details
     When they change the contact number
@@ -31,7 +31,7 @@ Feature: As an internal user
     And they are provided with confirmation the changes have been saved
 
   @us057-s04
-  @fixture.setup.data.enrolled.respondent
+  @fixture.setup.data.with.enrolled.respondent.user.and.response.user
   Scenario: The internal user is able to cancel out of changing the respondent details at any point
     Given the internal user chooses to change account details
     When they change the contact number
@@ -40,7 +40,7 @@ Feature: As an internal user
     And the contact number is not changed
 
   @us058-s001
-  @fixture.setup.data.enrolled.respondent
+  @fixture.setup.data.with.enrolled.respondent.user.and.response.user
   Scenario: The user is able to edit the email address of a respondent
     Given the internal user has found the respondents details
     When they change the email address
@@ -49,7 +49,7 @@ Feature: As an internal user
     And they can see the old and the unverified new email
 
   @us058-s002
-  @fixture.setup.data.enrolled.respondent
+  @fixture.setup.data.with.enrolled.respondent.user.and.response.user
   Scenario: The user is able to cancel out of changing the respondent details at any point
     Given the internal user chooses to change account details
     When they change the email address
@@ -58,7 +58,7 @@ Feature: As an internal user
     And the email is not changed
 
   @us058-s003
-  @fixture.setup.data.2.enrolled.respondents
+  @fixture.setup.data.with.2.enrolled.respondent.users.and.response.user
   Scenario: The user is to be informed if the email address entered is already in use and is unable to save
     Given the internal user chooses to change account details
     When they save an email address that is already in use

--- a/acceptance_tests/features/edit_respondent_details.feature
+++ b/acceptance_tests/features/edit_respondent_details.feature
@@ -7,14 +7,14 @@ Feature: As an internal user
     Given the internal user is already signed in
 
   @us057-s01
-  @fixture.setup.data.with.enrolled.respondent.user.and.response.user
+  @fixture.setup.data.with.enrolled.respondent.user.and.internal.user
   Scenario: The internal user is able to change a respondents first name, last name and contact number
     Given the internal user has found the respondents details
     When they choose to change the name of a respondent
     Then the respondent account details become editable
 
   @us057-s02
-  @fixture.setup.data.with.enrolled.respondent.user.and.response.user
+  @fixture.setup.data.with.enrolled.respondent.user.and.internal.user
   Scenario: All fields are required to be populated
     Given the internal user chooses to change account details
     When they remove the old contact number
@@ -22,7 +22,7 @@ Feature: As an internal user
     Then the changes will not be saved and they are informed that all fields are required
 
   @us057-s03
-  @fixture.setup.data.with.enrolled.respondent.user.and.response.user
+  @fixture.setup.data.with.enrolled.respondent.user.and.internal.user
   Scenario: The internal user is able to save any changes made to the account details
     Given the internal user chooses to change account details
     When they change the contact number
@@ -31,7 +31,7 @@ Feature: As an internal user
     And they are provided with confirmation the changes have been saved
 
   @us057-s04
-  @fixture.setup.data.with.enrolled.respondent.user.and.response.user
+  @fixture.setup.data.with.enrolled.respondent.user.and.internal.user
   Scenario: The internal user is able to cancel out of changing the respondent details at any point
     Given the internal user chooses to change account details
     When they change the contact number
@@ -40,7 +40,7 @@ Feature: As an internal user
     And the contact number is not changed
 
   @us058-s001
-  @fixture.setup.data.with.enrolled.respondent.user.and.response.user
+  @fixture.setup.data.with.enrolled.respondent.user.and.internal.user
   Scenario: The user is able to edit the email address of a respondent
     Given the internal user has found the respondents details
     When they change the email address
@@ -49,7 +49,7 @@ Feature: As an internal user
     And they can see the old and the unverified new email
 
   @us058-s002
-  @fixture.setup.data.with.enrolled.respondent.user.and.response.user
+  @fixture.setup.data.with.enrolled.respondent.user.and.internal.user
   Scenario: The user is able to cancel out of changing the respondent details at any point
     Given the internal user chooses to change account details
     When they change the email address
@@ -58,7 +58,7 @@ Feature: As an internal user
     And the email is not changed
 
   @us058-s003
-  @fixture.setup.data.with.2.enrolled.respondent.users.and.response.user
+  @fixture.setup.data.with.2.enrolled.respondent.users.and.internal.user
   Scenario: The user is to be informed if the email address entered is already in use and is unable to save
     Given the internal user chooses to change account details
     When they save an email address that is already in use

--- a/acceptance_tests/features/environment.py
+++ b/acceptance_tests/features/environment.py
@@ -6,16 +6,16 @@ from structlog import wrap_logger
 
 from acceptance_tests import browser
 from acceptance_tests.features.fixtures import \
-    setup_data_with_enrolled_respondent_user_and_response_user, \
+    setup_data_with_enrolled_respondent_user_and_internal_user, \
     setup_data_with_unenrolled_respondent_user, \
     setup_data_with_unenrolled_respondent_user_and_new_iac_and_collection_exercise_to_live, \
     setup_data_with_unenrolled_respondent_user_and_new_iac, \
-    setup_data_with_enrolled_respondent_user_and_response_user_and_new_iac_and_collection_exercise_to_live, \
-    setup_data_with_2_enrolled_respondent_users_and_response_user, \
-    setup_data_with_response_user_and_social_collection_exercise_to_closed_status, \
-    setup_data_with_response_user_and_collection_exercise_to_created_status, setup_data_with_response_user, \
-    setup_with_response_user, \
-    setup_data_with_unenrolled_respondent_user_and_response_user
+    setup_data_with_enrolled_respondent_user_and_internal_user_and_new_iac_and_collection_exercise_to_live, \
+    setup_data_with_2_enrolled_respondent_users_and_internal_user, \
+    setup_data_with_internal_user_and_social_collection_exercise_to_closed_status, \
+    setup_data_with_internal_user_and_collection_exercise_to_created_status, setup_data_with_response_user, \
+    setup_with_internal_user, \
+    setup_data_with_unenrolled_respondent_user_and_internal_user
 from common import survey_utilities
 from config import Config
 from exceptions import MissingFixtureError
@@ -32,28 +32,28 @@ timings = {}
 
 
 fixture_scenario_registry = {
-    'fixture.setup.with.response.user':
-        setup_with_response_user,
-    'fixture.setup.data.with.response.user':
+    'fixture.setup.with.internal.user':
+        setup_with_internal_user,
+    'fixture.setup.data.with.internal.user':
         setup_data_with_response_user,
-    'fixture.setup.data.with.enrolled.respondent.user.and.response.user':
-        setup_data_with_enrolled_respondent_user_and_response_user,
+    'fixture.setup.data.with.enrolled.respondent.user.and.internal.user':
+        setup_data_with_enrolled_respondent_user_and_internal_user,
     'fixture.setup.data.with.unenrolled.respondent.user':
         setup_data_with_unenrolled_respondent_user,
-    'fixture.setup.data.with.unenrolled.respondent.user.and.response.user':
-        setup_data_with_unenrolled_respondent_user_and_response_user,
+    'fixture.setup.data.with.unenrolled.respondent.user.and.internal.user':
+        setup_data_with_unenrolled_respondent_user_and_internal_user,
     'fixture.setup.data.with.unenrolled.respondent.user.and.new.iac':
         setup_data_with_unenrolled_respondent_user_and_new_iac,
-    'fixture.setup.data.with.response.user.and.collection.exercise.to.created.status':
-        setup_data_with_response_user_and_collection_exercise_to_created_status,
-    'fixture.setup.data.with.response.user.and.social.collection.exercise.to.closed.status':
-        setup_data_with_response_user_and_social_collection_exercise_to_closed_status,
+    'fixture.setup.data.with.internal.user.and.collection.exercise.to.created.status':
+        setup_data_with_internal_user_and_collection_exercise_to_created_status,
+    'fixture.setup.data.with.internal.user.and.social.collection.exercise.to.closed.status':
+        setup_data_with_internal_user_and_social_collection_exercise_to_closed_status,
     'fixture.setup.data.with.unenrolled.respondent.user.and.new.iac.and.collection.exercise.to.live':
         setup_data_with_unenrolled_respondent_user_and_new_iac_and_collection_exercise_to_live,
-    'fixture.setup.data.with.enrolled.respondent.user.and.response.user.and.new.iac.and.collection.exercise.to.live':
-        setup_data_with_enrolled_respondent_user_and_response_user_and_new_iac_and_collection_exercise_to_live,
-    'fixture.setup.data.with.2.enrolled.respondent.users.and.response.user':
-        setup_data_with_2_enrolled_respondent_users_and_response_user
+    'fixture.setup.data.with.enrolled.respondent.user.and.internal.user.and.new.iac.and.collection.exercise.to.live':
+        setup_data_with_enrolled_respondent_user_and_internal_user_and_new_iac_and_collection_exercise_to_live,
+    'fixture.setup.data.with.2.enrolled.respondent.users.and.internal.user':
+        setup_data_with_2_enrolled_respondent_users_and_internal_user
 }
 
 
@@ -89,7 +89,7 @@ def before_scenario(context, scenario):
 
     # Default to non-standalone fixed user name, standalone mode changes it
     context.respondent_user_name = Config.RESPONDENT_USERNAME
-    context.response_user_name = Config.INTERNAL_USERNAME
+    context.internal_user_name = Config.INTERNAL_USERNAME
 
     # Run any custom scenario setup from fixture tags
     process_scenario_fixtures(context)

--- a/acceptance_tests/features/environment.py
+++ b/acceptance_tests/features/environment.py
@@ -5,13 +5,17 @@ from behave import use_fixture
 from structlog import wrap_logger
 
 from acceptance_tests import browser
-from acceptance_tests.features import fixtures
 from acceptance_tests.features.fixtures import \
-    setup_enrolled_respondent, \
-    setup_unenrolled_respondent, setup_default_data, \
-    setup_unenrolled_respondent_generate_new_iac_collection_exercise_to_live_status, \
-    setup_unenrolled_respondent_generate_new_iac, \
-    setup_enrolled_respondent_generate_new_iac_collection_exercise_to_live_status, setup_data_2_enrolled_respondents
+    setup_data_with_enrolled_respondent_user_and_response_user, \
+    setup_data_with_unenrolled_respondent_user, \
+    setup_data_with_unenrolled_respondent_user_and_new_iac_and_collection_exercise_to_live, \
+    setup_data_with_unenrolled_respondent_user_and_new_iac, \
+    setup_data_with_enrolled_respondent_user_and_response_user_and_new_iac_and_collection_exercise_to_live, \
+    setup_data_with_2_enrolled_respondent_users_and_response_user, \
+    setup_data_with_response_user_and_social_collection_exercise_to_closed_status, \
+    setup_data_with_response_user_and_collection_exercise_to_created_status, setup_data_with_response_user, \
+    setup_with_response_user, \
+    setup_data_with_unenrolled_respondent_user_and_response_user
 from common import survey_utilities
 from config import Config
 from exceptions import MissingFixtureError
@@ -26,19 +30,30 @@ logger = wrap_logger(getLogger(__name__))
 
 timings = {}
 
-fixture_scenario_registry = {
-    'fixture.setup.data.default': setup_default_data,
 
-    'fixture.setup.data.enrolled.respondent': setup_enrolled_respondent,
-    'fixture.setup.data.unenrolled.respondent': setup_unenrolled_respondent,
-    'fixture.setup.data.unenrolled.respondent.generate.new.iac': setup_unenrolled_respondent_generate_new_iac,
-    'fixture.setup.data.collection.exercise.created': fixtures.setup_collection_exercise_to_created_status,
-    'fixture.setup.data.collection.exercise.closed.social': fixtures.setup_collection_exercise_to_closed_status,
-    'fixture.setup.data.unenrolled.respondent.generate.new.iac.collection.exercise.live':
-        setup_unenrolled_respondent_generate_new_iac_collection_exercise_to_live_status,
-    'fixture.setup.data.enrolled.respondent.generate.new.iac.collection.exercise.live':
-        setup_enrolled_respondent_generate_new_iac_collection_exercise_to_live_status,
-    'fixture.setup.data.2.enrolled.respondents': setup_data_2_enrolled_respondents
+fixture_scenario_registry = {
+    'fixture.setup.with.response.user':
+        setup_with_response_user,
+    'fixture.setup.data.with.response.user':
+        setup_data_with_response_user,
+    'fixture.setup.data.with.enrolled.respondent.user.and.response.user':
+        setup_data_with_enrolled_respondent_user_and_response_user,
+    'fixture.setup.data.with.unenrolled.respondent.user':
+        setup_data_with_unenrolled_respondent_user,
+    'fixture.setup.data.with.unenrolled.respondent.user.and.response.user':
+        setup_data_with_unenrolled_respondent_user_and_response_user,
+    'fixture.setup.data.with.unenrolled.respondent.user.and.new.iac':
+        setup_data_with_unenrolled_respondent_user_and_new_iac,
+    'fixture.setup.data.with.response.user.and.collection.exercise.to.created.status':
+        setup_data_with_response_user_and_collection_exercise_to_created_status,
+    'fixture.setup.data.with.response.user.and.social.collection.exercise.to.closed.status':
+        setup_data_with_response_user_and_social_collection_exercise_to_closed_status,
+    'fixture.setup.data.with.unenrolled.respondent.user.and.new.iac.and.collection.exercise.to.live':
+        setup_data_with_unenrolled_respondent_user_and_new_iac_and_collection_exercise_to_live,
+    'fixture.setup.data.with.enrolled.respondent.user.and.response.user.and.new.iac.and.collection.exercise.to.live':
+        setup_data_with_enrolled_respondent_user_and_response_user_and_new_iac_and_collection_exercise_to_live,
+    'fixture.setup.data.with.2.enrolled.respondent.users.and.response.user':
+        setup_data_with_2_enrolled_respondent_users_and_response_user
 }
 
 
@@ -73,7 +88,8 @@ def before_scenario(context, scenario):
     logger.info(f'Running Feature [{context.feature_name}], Scenario [{context.scenario_name}]')
 
     # Default to non-standalone fixed user name, standalone mode changes it
-    context.user_name = Config.RESPONDENT_USERNAME
+    context.respondent_user_name = Config.RESPONDENT_USERNAME
+    context.response_user_name = Config.INTERNAL_USERNAME
 
     # Run any custom scenario setup from fixture tags
     process_scenario_fixtures(context)

--- a/acceptance_tests/features/fixtures.py
+++ b/acceptance_tests/features/fixtures.py
@@ -1,34 +1,42 @@
 from behave import fixture
 
+from common import response_utilities
 from common.survey_utilities import create_default_data, create_enrolled_respondent_for_the_test_survey, \
     COLLECTION_EXERCISE_STATUS_LIVE, create_unenrolled_respondent, create_data_for_survey, create_test_survey, \
     create_data_for_collection_exercise, \
-    create_test_business_collection_exercise, COLLECTION_EXERCISE_STATUS_CREATED
+    create_test_business_collection_exercise, COLLECTION_EXERCISE_STATUS_CREATED, create_ru_reference
 from controllers import collection_exercise_controller
 
 
-# todo lots of refactoring in here when all done
+@fixture
+def setup_with_response_user(context):
+    create_response_user(context)
+
 
 @fixture
-def setup_default_data(context):
-    """ Create the default Survey and Collection Exercise """
+def setup_data_with_response_user(context):
     create_default_data(context)
+    create_response_user(context)
 
 
 @fixture
-def setup_collection_exercise_to_closed_status(context):
+def setup_data_with_response_user_and_social_collection_exercise_to_closed_status(context):
     """ Creates a collection exercise that has mandatory dates in the past """
-
     context.period_offset_days = -365
     setup_default_data(context)
 
+    create_response_user(context)
+
 
 @fixture
-def setup_enrolled_respondent(context, generate_new_iac=False, wait_for_collection_exercise_state=None):
+def setup_data_with_enrolled_respondent_user_and_response_user(context, generate_new_iac=False,
+                                                               wait_for_collection_exercise_state=None):
     """ Creates default data + an enrolled Respondent in the default collection exercise """
     setup_default_data(context)
 
     create_enrolled_respondent_for_the_test_survey(context, generate_new_iac)
+
+    create_response_user(context)
 
     if wait_for_collection_exercise_state:
         collection_exercise_controller.wait_for_collection_exercise_state(context.survey_id, context.period,
@@ -36,7 +44,8 @@ def setup_enrolled_respondent(context, generate_new_iac=False, wait_for_collecti
 
 
 @fixture
-def setup_unenrolled_respondent(context, generate_new_iac=False, wait_for_collection_exercise_state=None):
+def setup_data_with_unenrolled_respondent_user(context, generate_new_iac=False,
+                                               wait_for_collection_exercise_state=None):
     """
     Creates default data + an unenrolled Respondent
     :param context:
@@ -54,15 +63,21 @@ def setup_unenrolled_respondent(context, generate_new_iac=False, wait_for_collec
 
 
 @fixture
-def setup_unenrolled_respondent_generate_new_iac(context):
-    """ Creates default data, an unenrolled Respondent and generates a new unused iac """
-    setup_unenrolled_respondent(context)
+def setup_data_with_unenrolled_respondent_user_and_response_user(context):
+    setup_data_with_unenrolled_respondent_user(context)
+
+    create_response_user(context)
 
 
 @fixture
-def setup_collection_exercise_to_created_status(context):
-    """ Creates default survey + collection exercise state = created """
+def setup_data_with_unenrolled_respondent_user_and_new_iac(context):
+    """ Creates default data, an unenrolled Respondent and generates a new unused iac """
+    setup_data_with_unenrolled_respondent_user(context, generate_new_iac=True)
 
+
+@fixture
+def setup_data_with_response_user_and_collection_exercise_to_created_status(context):
+    """ Creates default survey + collection exercise state = created """
     survey_data = create_data_for_survey(context)
     period = survey_data['period']
     short_name = survey_data['short_name']
@@ -84,27 +99,30 @@ def setup_collection_exercise_to_created_status(context):
     create_test_business_collection_exercise(survey_id, period, short_name, ce_name, survey_type,
                                              stop_at_state=COLLECTION_EXERCISE_STATUS_CREATED)
 
+    create_response_user(context)
+
 
 @fixture
-def setup_unenrolled_respondent_generate_new_iac_collection_exercise_to_live_status(context):
+def setup_data_with_unenrolled_respondent_user_and_new_iac_and_collection_exercise_to_live(context):
     """ Creates default data, an unenrolled Respondent, generates a new unused iac
     and waits until collection exercise state = live """
-    setup_unenrolled_respondent(context, generate_new_iac=True,
-                                wait_for_collection_exercise_state=COLLECTION_EXERCISE_STATUS_LIVE)
+    setup_data_with_unenrolled_respondent_user(context, generate_new_iac=True,
+                                               wait_for_collection_exercise_state=COLLECTION_EXERCISE_STATUS_LIVE)
 
 
+#todo shorten method names
 @fixture
-def setup_enrolled_respondent_generate_new_iac_collection_exercise_to_live_status(context):
+def setup_data_with_enrolled_respondent_user_and_response_user_and_new_iac_and_collection_exercise_to_live(context):
     """ Creates default data, an enrolled Respondent, generates a new unused iac
     and waits until collection exercise state = live """
-    setup_enrolled_respondent(context, generate_new_iac=True,
-                              wait_for_collection_exercise_state=COLLECTION_EXERCISE_STATUS_LIVE)
+    setup_data_with_enrolled_respondent_user_and_response_user(context, generate_new_iac=True,
+                                                               wait_for_collection_exercise_state=COLLECTION_EXERCISE_STATUS_LIVE)
 
 
 @fixture
-def setup_data_2_enrolled_respondents(context):
+def setup_data_with_2_enrolled_respondent_users_and_response_user(context):
     """ Creates default survey + 2 enrolled respondents in 2 collection exercises """
-    setup_enrolled_respondent(context)
+    setup_data_with_enrolled_respondent_user_and_response_user(context)
 
     # Save 1st collection exercise details - will probably need more depending on use?
     ce1_short_name = context.short_name
@@ -125,3 +143,14 @@ def setup_data_2_enrolled_respondents(context):
 
     # Restore 1st collection exercise details
     context.short_name = ce1_short_name
+
+
+def setup_default_data(context):
+    """ Create the default Survey and Collection Exercise """
+    create_default_data(context)
+
+
+def create_response_user(context):
+    context.response_user_name = getattr(context, 'short_name', create_ru_reference())
+
+    response_utilities.create_response_user_login_account(context.response_user_name)

--- a/acceptance_tests/features/fixtures.py
+++ b/acceptance_tests/features/fixtures.py
@@ -1,6 +1,6 @@
 from behave import fixture
 
-from common import response_utilities
+from common import internal_utilities
 from common.survey_utilities import create_default_data, create_enrolled_respondent_for_the_test_survey, \
     COLLECTION_EXERCISE_STATUS_LIVE, create_unenrolled_respondent, create_data_for_survey, create_test_survey, \
     create_data_for_collection_exercise, \
@@ -9,7 +9,7 @@ from controllers import collection_exercise_controller
 
 
 @fixture
-def setup_with_response_user(context):
+def setup_with_internal_user(context):
     create_response_user(context)
 
 
@@ -20,7 +20,7 @@ def setup_data_with_response_user(context):
 
 
 @fixture
-def setup_data_with_response_user_and_social_collection_exercise_to_closed_status(context):
+def setup_data_with_internal_user_and_social_collection_exercise_to_closed_status(context):
     """ Creates a collection exercise that has mandatory dates in the past """
     context.period_offset_days = -365
     setup_default_data(context)
@@ -29,7 +29,7 @@ def setup_data_with_response_user_and_social_collection_exercise_to_closed_statu
 
 
 @fixture
-def setup_data_with_enrolled_respondent_user_and_response_user(context, generate_new_iac=False,
+def setup_data_with_enrolled_respondent_user_and_internal_user(context, generate_new_iac=False,
                                                                wait_for_collection_exercise_state=None):
     """ Creates default data + an enrolled Respondent in the default collection exercise """
     setup_default_data(context)
@@ -63,7 +63,7 @@ def setup_data_with_unenrolled_respondent_user(context, generate_new_iac=False,
 
 
 @fixture
-def setup_data_with_unenrolled_respondent_user_and_response_user(context):
+def setup_data_with_unenrolled_respondent_user_and_internal_user(context):
     setup_data_with_unenrolled_respondent_user(context)
 
     create_response_user(context)
@@ -76,7 +76,7 @@ def setup_data_with_unenrolled_respondent_user_and_new_iac(context):
 
 
 @fixture
-def setup_data_with_response_user_and_collection_exercise_to_created_status(context):
+def setup_data_with_internal_user_and_collection_exercise_to_created_status(context):
     """ Creates default survey + collection exercise state = created """
     survey_data = create_data_for_survey(context)
     period = survey_data['period']
@@ -110,19 +110,18 @@ def setup_data_with_unenrolled_respondent_user_and_new_iac_and_collection_exerci
                                                wait_for_collection_exercise_state=COLLECTION_EXERCISE_STATUS_LIVE)
 
 
-#todo shorten method names
 @fixture
-def setup_data_with_enrolled_respondent_user_and_response_user_and_new_iac_and_collection_exercise_to_live(context):
+def setup_data_with_enrolled_respondent_user_and_internal_user_and_new_iac_and_collection_exercise_to_live(context):
     """ Creates default data, an enrolled Respondent, generates a new unused iac
     and waits until collection exercise state = live """
-    setup_data_with_enrolled_respondent_user_and_response_user(context, generate_new_iac=True,
+    setup_data_with_enrolled_respondent_user_and_internal_user(context, generate_new_iac=True,
                                                                wait_for_collection_exercise_state=COLLECTION_EXERCISE_STATUS_LIVE)
 
 
 @fixture
-def setup_data_with_2_enrolled_respondent_users_and_response_user(context):
+def setup_data_with_2_enrolled_respondent_users_and_internal_user(context):
     """ Creates default survey + 2 enrolled respondents in 2 collection exercises """
-    setup_data_with_enrolled_respondent_user_and_response_user(context)
+    setup_data_with_enrolled_respondent_user_and_internal_user(context)
 
     # Save 1st collection exercise details - will probably need more depending on use?
     ce1_short_name = context.short_name
@@ -151,6 +150,6 @@ def setup_default_data(context):
 
 
 def create_response_user(context):
-    context.response_user_name = getattr(context, 'short_name', create_ru_reference())
+    context.internal_user_name = getattr(context, 'short_name', create_ru_reference())
 
-    response_utilities.create_response_user_login_account(context.response_user_name)
+    internal_utilities.create_internal_user_login_account(context.internal_user_name)

--- a/acceptance_tests/features/fixtures.py
+++ b/acceptance_tests/features/fixtures.py
@@ -30,7 +30,7 @@ def setup_data_with_internal_user_and_social_collection_exercise_to_closed_statu
 
 @fixture
 def setup_data_with_enrolled_respondent_user_and_internal_user(context, generate_new_iac=False,
-                                                               wait_for_collection_exercise_state=None):
+                                                               wait_ce_for_state=None):
     """ Creates default data + an enrolled Respondent in the default collection exercise """
     setup_default_data(context)
 
@@ -38,9 +38,9 @@ def setup_data_with_enrolled_respondent_user_and_internal_user(context, generate
 
     create_response_user(context)
 
-    if wait_for_collection_exercise_state:
+    if wait_ce_for_state:
         collection_exercise_controller.wait_for_collection_exercise_state(context.survey_id, context.period,
-                                                                          wait_for_collection_exercise_state)
+                                                                          wait_ce_for_state)
 
 
 @fixture
@@ -115,7 +115,7 @@ def setup_data_with_enrolled_respondent_user_and_internal_user_and_new_iac_and_c
     """ Creates default data, an enrolled Respondent, generates a new unused iac
     and waits until collection exercise state = live """
     setup_data_with_enrolled_respondent_user_and_internal_user(context, generate_new_iac=True,
-                                                               wait_for_collection_exercise_state=COLLECTION_EXERCISE_STATUS_LIVE)
+                                                               wait_ce_for_state=COLLECTION_EXERCISE_STATUS_LIVE)
 
 
 @fixture

--- a/acceptance_tests/features/generate_new_enrolment_code.feature
+++ b/acceptance_tests/features/generate_new_enrolment_code.feature
@@ -1,6 +1,6 @@
 @business
 @standalone
-@fixture.setup.data.unenrolled.respondent.generate.new.iac
+@fixture.setup.data.with.unenrolled.respondent.user.and.response.user
 Feature: Generate new enrolment code
   As an internal user
   I need to obtain a new enrolment code for a RU for a specific survey

--- a/acceptance_tests/features/generate_new_enrolment_code.feature
+++ b/acceptance_tests/features/generate_new_enrolment_code.feature
@@ -1,6 +1,6 @@
 @business
 @standalone
-@fixture.setup.data.with.unenrolled.respondent.user.and.response.user
+@fixture.setup.data.with.unenrolled.respondent.user.and.internal.user
 Feature: Generate new enrolment code
   As an internal user
   I need to obtain a new enrolment code for a RU for a specific survey

--- a/acceptance_tests/features/pages/enrolment_code.py
+++ b/acceptance_tests/features/pages/enrolment_code.py
@@ -1,4 +1,5 @@
 from acceptance_tests import browser
+from common.survey_utilities import make_email_address
 
 
 def get_new_iac():
@@ -7,3 +8,7 @@ def get_new_iac():
 
 def get_unused_iac():
     return browser.find_by_id('unused-enrolment-code')
+
+
+def generate_random_email_address():
+    return make_email_address()

--- a/acceptance_tests/features/pages/sign_in_internal.py
+++ b/acceptance_tests/features/pages/sign_in_internal.py
@@ -10,8 +10,8 @@ def get_page_title():
     return browser.title
 
 
-def enter_correct_username():
-    browser.driver.find_element_by_id('username').send_keys(str(Config.INTERNAL_USERNAME))
+def enter_correct_username(user_name):
+    browser.driver.find_element_by_id('username').send_keys(user_name)
 
 
 def enter_incorrect_username():

--- a/acceptance_tests/features/pages/social_sign_in_internal.py
+++ b/acceptance_tests/features/pages/social_sign_in_internal.py
@@ -10,8 +10,8 @@ def get_page_title():
     return browser.title
 
 
-def enter_correct_username():
-    browser.driver.find_element_by_id('username').send_keys(str(Config.INTERNAL_USERNAME))
+def enter_correct_username(user_name):
+    browser.driver.find_element_by_id('username').send_keys(user_name)
 
 
 def enter_incorrect_username():

--- a/acceptance_tests/features/search_respondent_by_email.feature
+++ b/acceptance_tests/features/search_respondent_by_email.feature
@@ -9,13 +9,14 @@ Feature: Internal user can search for a respondent via email
     Given the internal user is already signed in
 
   @us091_s01
-  @fixture.setup.data.unenrolled.respondent
+  @fixture.setup.data.with.unenrolled.respondent.user.and.response.user
   Scenario: Search verified respondent by email address
     Given the respondent account with an email has been created
     When an internal user searches for respondent using their email address
     Then the respondent details should be displayed
 
   @us091_s02
+  @fixture.setup.with.response.user
   Scenario: Search non-existent respondent by email address
     Given the respondent account with email "test@test.com" has not been created
     When the internal user searches for the respondent using the email "test@test.com"

--- a/acceptance_tests/features/search_respondent_by_email.feature
+++ b/acceptance_tests/features/search_respondent_by_email.feature
@@ -9,14 +9,14 @@ Feature: Internal user can search for a respondent via email
     Given the internal user is already signed in
 
   @us091_s01
-  @fixture.setup.data.with.unenrolled.respondent.user.and.response.user
+  @fixture.setup.data.with.unenrolled.respondent.user.and.internal.user
   Scenario: Search verified respondent by email address
     Given the respondent account with an email has been created
     When an internal user searches for respondent using their email address
     Then the respondent details should be displayed
 
   @us091_s02
-  @fixture.setup.with.response.user
+  @fixture.setup.with.internal.user
   Scenario: Search non-existent respondent by email address
     Given the respondent account with email "test@test.com" has not been created
     When the internal user searches for the respondent using the email "test@test.com"

--- a/acceptance_tests/features/sign_in_internal.feature
+++ b/acceptance_tests/features/sign_in_internal.feature
@@ -1,6 +1,6 @@
 @business
 @standalone
-@fixture.setup.with.response.user
+@fixture.setup.with.internal.user
 Feature: Internal user signs in
   As an internal user
   I need to sign in to the SDC system

--- a/acceptance_tests/features/sign_in_internal.feature
+++ b/acceptance_tests/features/sign_in_internal.feature
@@ -1,10 +1,10 @@
 @business
 @standalone
+@fixture.setup.with.response.user
 Feature: Internal user signs in
   As an internal user
   I need to sign in to the SDC system
   So that I can access my SDC account and carry out a number of actions
-
 
   Scenario: User signs in correctly
     Given the user has an active account and is assigned a username and password

--- a/acceptance_tests/features/sign_out_internal.feature
+++ b/acceptance_tests/features/sign_out_internal.feature
@@ -1,6 +1,6 @@
 @business
 @standalone
-@fixture.setup.with.response.user
+@fixture.setup.with.internal.user
 Feature: Internal user signs out
   As an internal user
   I need to sign out of the SDC system

--- a/acceptance_tests/features/sign_out_internal.feature
+++ b/acceptance_tests/features/sign_out_internal.feature
@@ -1,5 +1,6 @@
 @business
 @standalone
+@fixture.setup.with.response.user
 Feature: Internal user signs out
   As an internal user
   I need to sign out of the SDC system

--- a/acceptance_tests/features/site_navigation.feature
+++ b/acceptance_tests/features/site_navigation.feature
@@ -1,6 +1,6 @@
 @business
 @standalone
-@fixture.setup.data.default
+@fixture.setup.data.with.response.user
 Feature: Site navigation
   As a Product Owner
   I need my users to easily navigate through the internal system

--- a/acceptance_tests/features/site_navigation.feature
+++ b/acceptance_tests/features/site_navigation.feature
@@ -1,6 +1,6 @@
 @business
 @standalone
-@fixture.setup.data.with.response.user
+@fixture.setup.data.with.internal.user
 Feature: Site navigation
   As a Product Owner
   I need my users to easily navigate through the internal system

--- a/acceptance_tests/features/social_change_case_status.feature
+++ b/acceptance_tests/features/social_change_case_status.feature
@@ -1,6 +1,6 @@
 @social
 @standalone
-@fixture.setup.data.with.response.user
+@fixture.setup.data.with.internal.user
 Feature: Change Response Status
   As a: Survey Enquiry Line User
   I need: To be able to change the response status to an outcome that requires no further action

--- a/acceptance_tests/features/social_change_case_status.feature
+++ b/acceptance_tests/features/social_change_case_status.feature
@@ -1,6 +1,6 @@
 @social
 @standalone
-@fixture.setup.data.default
+@fixture.setup.data.with.response.user
 Feature: Change Response Status
   As a: Survey Enquiry Line User
   I need: To be able to change the response status to an outcome that requires no further action

--- a/acceptance_tests/features/social_disable_uac.feature
+++ b/acceptance_tests/features/social_disable_uac.feature
@@ -1,6 +1,6 @@
 @social
 @standalone
-@fixture.setup.data.with.response.user
+@fixture.setup.data.with.internal.user
 Feature: Change Response Status to 'Partial interview achieved but respondent requested data be deleted'
   As a: Survey Enquiry Line User
   I need: To be able to disable all UACs for a case when the response status is changed to 'Partial interview achieved but respondent requested data be deleted'

--- a/acceptance_tests/features/social_disable_uac.feature
+++ b/acceptance_tests/features/social_disable_uac.feature
@@ -1,6 +1,6 @@
 @social
 @standalone
-@fixture.setup.data.default
+@fixture.setup.data.with.response.user
 Feature: Change Response Status to 'Partial interview achieved but respondent requested data be deleted'
   As a: Survey Enquiry Line User
   I need: To be able to disable all UACs for a case when the response status is changed to 'Partial interview achieved but respondent requested data be deleted'

--- a/acceptance_tests/features/social_find_case_by_postcode.feature
+++ b/acceptance_tests/features/social_find_case_by_postcode.feature
@@ -1,6 +1,6 @@
 @social
 @standalone
-@fixture.setup.data.default
+@fixture.setup.data.with.response.user
 Feature: Search social cases by postcode
   As a Survey Enquiry Line User
   I need to be able find a case by entering a postcode

--- a/acceptance_tests/features/social_find_case_by_postcode.feature
+++ b/acceptance_tests/features/social_find_case_by_postcode.feature
@@ -1,6 +1,6 @@
 @social
 @standalone
-@fixture.setup.data.with.response.user
+@fixture.setup.data.with.internal.user
 Feature: Search social cases by postcode
   As a Survey Enquiry Line User
   I need to be able find a case by entering a postcode

--- a/acceptance_tests/features/social_sign_in_internal.feature
+++ b/acceptance_tests/features/social_sign_in_internal.feature
@@ -1,5 +1,6 @@
 @social
 @standalone
+@fixture.setup.with.response.user
 Feature: Internal user signs in to social UI
   As an internal user
   I need to sign in to the social SDC system

--- a/acceptance_tests/features/social_sign_in_internal.feature
+++ b/acceptance_tests/features/social_sign_in_internal.feature
@@ -1,6 +1,6 @@
 @social
 @standalone
-@fixture.setup.with.response.user
+@fixture.setup.with.internal.user
 Feature: Internal user signs in to social UI
   As an internal user
   I need to sign in to the social SDC system

--- a/acceptance_tests/features/social_sign_out_internal.feature
+++ b/acceptance_tests/features/social_sign_out_internal.feature
@@ -1,6 +1,6 @@
 @social
 @standalone
-@fixture.setup.with.response.user
+@fixture.setup.with.internal.user
 Feature: Internal user signs out from social
   As an internal user
   I need to sign out of the social SDC system

--- a/acceptance_tests/features/social_sign_out_internal.feature
+++ b/acceptance_tests/features/social_sign_out_internal.feature
@@ -1,5 +1,6 @@
 @social
 @standalone
+@fixture.setup.with.response.user
 Feature: Internal user signs out from social
   As an internal user
   I need to sign out of the social SDC system

--- a/acceptance_tests/features/social_view_case_details.feature
+++ b/acceptance_tests/features/social_view_case_details.feature
@@ -1,6 +1,6 @@
 @social
 @standalone
-@fixture.setup.data.default
+@fixture.setup.data.with.response.user
 Feature: View social case details
   As a Survey Enquiry Line User
   I need to be able to view the case details in relation to the call I have received

--- a/acceptance_tests/features/social_view_case_details.feature
+++ b/acceptance_tests/features/social_view_case_details.feature
@@ -1,6 +1,6 @@
 @social
 @standalone
-@fixture.setup.data.with.response.user
+@fixture.setup.data.with.internal.user
 Feature: View social case details
   As a Survey Enquiry Line User
   I need to be able to view the case details in relation to the call I have received

--- a/acceptance_tests/features/social_view_closed_case_details.feature
+++ b/acceptance_tests/features/social_view_closed_case_details.feature
@@ -1,6 +1,6 @@
 @social
 @standalone
-@fixture.setup.data.collection.exercise.closed.social
+@fixture.setup.data.with.response.user.and.social.collection.exercise.to.closed.status
 Feature: HAC cannot be generated if the collection exercise has closed
   As a Survey Enquiry Line User
   I need to ensure that a new code cannot be generated if the collection exercise has closed

--- a/acceptance_tests/features/social_view_closed_case_details.feature
+++ b/acceptance_tests/features/social_view_closed_case_details.feature
@@ -1,6 +1,6 @@
 @social
 @standalone
-@fixture.setup.data.with.response.user.and.social.collection.exercise.to.closed.status
+@fixture.setup.data.with.internal.user.and.social.collection.exercise.to.closed.status
 Feature: HAC cannot be generated if the collection exercise has closed
   As a Survey Enquiry Line User
   I need to ensure that a new code cannot be generated if the collection exercise has closed

--- a/acceptance_tests/features/steps/authentication.py
+++ b/acceptance_tests/features/steps/authentication.py
@@ -11,26 +11,32 @@ def signed_in_respondent(context):
     sign_in_respondent.go_to()
     # Only attempt to sign in if not already signed in otherwise implicitly redirected to homepage
     if '/sign-in' in browser.url:
-        browser.driver.find_element_by_id('username').send_keys(context.user_name)
+        browser.driver.find_element_by_id('username').send_keys(context.respondent_user_name)
         browser.driver.find_element_by_id('inputPassword').send_keys(Config.RESPONDENT_PASSWORD)
         browser.find_by_id('sign_in_button').click()
 
 
 @given('The internal user is already signed in')
-def signed_in_internal(_):
+def signed_in_internal(context):
     sign_in_internal.go_to()
     # Only attempt to sign in if not already signed in otherwise implicitly redirected to homepage
     if '/sign-in' in browser.url:
-        sign_in_internal.enter_correct_username()
+        # todo temp fix until all converted
+        response_user_name = getattr(context, 'response_user_name', Config.INTERNAL_USERNAME)
+
+        sign_in_internal.enter_correct_username(response_user_name)
         sign_in_internal.enter_correct_password()
         sign_in_internal.click_internal_sign_in_button()
 
 
 @given('The internal user is already signed in to social UI')
-def signed_in_internal_social(_):
+def signed_in_internal_social(context):
     social_sign_in_internal.go_to()
     # Only attempt to sign in if not already signed in otherwise implicitly redirected to homepage
     if '/sign-in' in browser.url:
-        sign_in_internal.enter_correct_username()
+        # todo temp fix until all converted
+        response_user_name = getattr(context, 'response_user_name', Config.INTERNAL_USERNAME)
+
+        sign_in_internal.enter_correct_username(response_user_name)
         sign_in_internal.enter_correct_password()
         sign_in_internal.click_internal_sign_in_button()

--- a/acceptance_tests/features/steps/authentication.py
+++ b/acceptance_tests/features/steps/authentication.py
@@ -22,9 +22,9 @@ def signed_in_internal(context):
     # Only attempt to sign in if not already signed in otherwise implicitly redirected to homepage
     if '/sign-in' in browser.url:
         # todo temp fix until all converted
-        response_user_name = getattr(context, 'response_user_name', Config.INTERNAL_USERNAME)
+        internal_user_name = getattr(context, 'internal_user_name', Config.INTERNAL_USERNAME)
 
-        sign_in_internal.enter_correct_username(response_user_name)
+        sign_in_internal.enter_correct_username(internal_user_name)
         sign_in_internal.enter_correct_password()
         sign_in_internal.click_internal_sign_in_button()
 
@@ -35,8 +35,8 @@ def signed_in_internal_social(context):
     # Only attempt to sign in if not already signed in otherwise implicitly redirected to homepage
     if '/sign-in' in browser.url:
         # todo temp fix until all converted
-        response_user_name = getattr(context, 'response_user_name', Config.INTERNAL_USERNAME)
+        internal_user_name = getattr(context, 'internal_user_name', Config.INTERNAL_USERNAME)
 
-        sign_in_internal.enter_correct_username(response_user_name)
+        sign_in_internal.enter_correct_username(internal_user_name)
         sign_in_internal.enter_correct_password()
         sign_in_internal.click_internal_sign_in_button()

--- a/acceptance_tests/features/steps/edit_respondent_details.py
+++ b/acceptance_tests/features/steps/edit_respondent_details.py
@@ -18,7 +18,7 @@ def respondent_is_enrolled_and_active(_, email):
 def open_edit_details_change_email(context):
     reporting_unit.go_to(context.short_name)
     reporting_unit.click_data_panel(context.short_name)
-    reporting_unit.click_edit_details(context.short_name, context.user_name)
+    reporting_unit.click_edit_details(context.short_name, context.respondent_user_name)
 
 
 @when('they choose to change the name of a respondent')
@@ -46,7 +46,7 @@ def edit_email_address(context):
 
 @when('they save an email address that is already in use')
 def save_email_already_in_use(context):
-    context.used_email_address = get_different_respondent_email_address(context.user_name)
+    context.used_email_address = get_different_respondent_email_address(context.respondent_user_name)
     edit_respondent_details_form.edit_email_address(context.used_email_address)
     edit_respondent_details_form.click_save()
 
@@ -90,8 +90,8 @@ def confirm_email_changes_saved(_):
 @then('they can see the old and the unverified new email')
 def view_pending_email(context):
     reporting_unit.click_data_panel(context.short_name)
-    respondent = reporting_unit.get_respondent(context.short_name, context.user_name)
-    assert respondent.get('email') == context.user_name
+    respondent = reporting_unit.get_respondent(context.short_name, context.respondent_user_name)
+    assert respondent.get('email') == context.respondent_user_name
     assert respondent.get('pending_email') == context.changed_email_address
 
 
@@ -106,7 +106,7 @@ def confirm_contact_number_unchanged(context):
 def confirm_email_unchanged(context):
     reporting_unit.click_data_panel(context.short_name)
     respondent = reporting_unit.get_associated_respondents(context.short_name)[0]
-    assert respondent.get('email') == context.user_name
+    assert respondent.get('email') == context.respondent_user_name
 
 
 @then('they are informed that the email address they have entered is already in use')

--- a/acceptance_tests/features/steps/find_respondent_by_email.py
+++ b/acceptance_tests/features/steps/find_respondent_by_email.py
@@ -6,22 +6,23 @@ from controllers.party_controller import get_party_by_email
 
 @given('the respondent account with an email has been created')
 def create_respondent_account(context):
-    respondent_party = get_party_by_email(context.user_name)
+    respondent_party = get_party_by_email(context.respondent_user_name)
 
-    assert respondent_party is not None, f'No respondent with email {context.user_name} exists'
+    assert respondent_party is not None, f'No respondent with email {context.respondent_user_name} exists'
 
 
 @when('an internal user searches for respondent using their email address')
 def search_respondent_by_email(context):
     respondent.go_to_find_respondent()
-    respondent.search_respondent_by_email(context.user_name)
+    respondent.search_respondent_by_email(context.respondent_user_name)
 
 
 @then('the respondent details should be displayed')
 def assert_respondent_details_displayed(context):
     respondent_details = respondent.get_respondent_details()
 
-    assert context.user_name in respondent_details['email'], "No respondent with email " + context.user_name
+    assert context.respondent_user_name in respondent_details[
+        'email'], "No respondent with email " + context.respondent_user_name
 
 
 @then('the internal user is given a message of no respondent for email')

--- a/acceptance_tests/features/steps/sign_in_internal.py
+++ b/acceptance_tests/features/steps/sign_in_internal.py
@@ -28,7 +28,7 @@ def try_sign_out():
 
 @when('they enter the correct username and password')
 def sign_in_correct_username_and_password(context):
-    sign_in_internal.enter_correct_username(context.response_user_name)
+    sign_in_internal.enter_correct_username(context.internal_user_name)
     sign_in_internal.enter_correct_password()
     sign_in_internal.click_internal_sign_in_button()
 
@@ -42,7 +42,7 @@ def sign_in_incorrect_username_and_correct_password(_):
 
 @when('they enter a correct username and incorrect password')
 def sign_in_correct_username_and_incorrect_password(context):
-    sign_in_internal.enter_correct_username(context.response_user_name)
+    sign_in_internal.enter_correct_username(context.internal_user_name)
     sign_in_internal.enter_incorrect_password()
     sign_in_internal.click_internal_sign_in_button()
 
@@ -56,7 +56,7 @@ def sign_in_incorrect_username_and_password(_):
 
 @when('they enter a correct username and no password')
 def sign_in_correct_username_and_no_password(context):
-    sign_in_internal.enter_correct_username(context.response_user_name)
+    sign_in_internal.enter_correct_username(context.internal_user_name)
     sign_in_internal.click_internal_sign_in_button()
 
 

--- a/acceptance_tests/features/steps/sign_in_internal.py
+++ b/acceptance_tests/features/steps/sign_in_internal.py
@@ -5,7 +5,6 @@ from structlog import wrap_logger
 
 from acceptance_tests.features.pages import sign_in_internal, home, sign_out_internal
 
-
 logger = wrap_logger(logging.getLogger(__name__))
 
 
@@ -28,8 +27,8 @@ def try_sign_out():
 
 
 @when('they enter the correct username and password')
-def sign_in_correct_username_and_password(_):
-    sign_in_internal.enter_correct_username()
+def sign_in_correct_username_and_password(context):
+    sign_in_internal.enter_correct_username(context.response_user_name)
     sign_in_internal.enter_correct_password()
     sign_in_internal.click_internal_sign_in_button()
 
@@ -42,8 +41,8 @@ def sign_in_incorrect_username_and_correct_password(_):
 
 
 @when('they enter a correct username and incorrect password')
-def sign_in_correct_username_and_incorrect_password(_):
-    sign_in_internal.enter_correct_username()
+def sign_in_correct_username_and_incorrect_password(context):
+    sign_in_internal.enter_correct_username(context.response_user_name)
     sign_in_internal.enter_incorrect_password()
     sign_in_internal.click_internal_sign_in_button()
 
@@ -56,8 +55,8 @@ def sign_in_incorrect_username_and_password(_):
 
 
 @when('they enter a correct username and no password')
-def sign_in_correct_username_and_no_password(_):
-    sign_in_internal.enter_correct_username()
+def sign_in_correct_username_and_no_password(context):
+    sign_in_internal.enter_correct_username(context.response_user_name)
     sign_in_internal.click_internal_sign_in_button()
 
 

--- a/acceptance_tests/features/steps/social_sign_in_internal.py
+++ b/acceptance_tests/features/steps/social_sign_in_internal.py
@@ -28,7 +28,7 @@ def try_sign_out():
 
 @when('they enter the correct username and password (social)')
 def sign_in_correct_username_and_password(context):
-    social_sign_in_internal.enter_correct_username(context.response_user_name)
+    social_sign_in_internal.enter_correct_username(context.internal_user_name)
     social_sign_in_internal.enter_correct_password()
     social_sign_in_internal.click_internal_sign_in_button()
 
@@ -42,7 +42,7 @@ def sign_in_incorrect_username_and_correct_password(_):
 
 @when('they enter a correct username and incorrect password (social)')
 def sign_in_correct_username_and_incorrect_password(context):
-    social_sign_in_internal.enter_correct_username(context.response_user_name)
+    social_sign_in_internal.enter_correct_username(context.internal_user_name)
     social_sign_in_internal.enter_incorrect_password()
     social_sign_in_internal.click_internal_sign_in_button()
 
@@ -56,7 +56,7 @@ def sign_in_incorrect_username_and_password(_):
 
 @when('they enter a correct username and no password (social)')
 def sign_in_correct_username_and_no_password(context):
-    social_sign_in_internal.enter_correct_username(context.response_user_name)
+    social_sign_in_internal.enter_correct_username(context.internal_user_name)
     social_sign_in_internal.click_internal_sign_in_button()
 
 

--- a/acceptance_tests/features/steps/social_sign_in_internal.py
+++ b/acceptance_tests/features/steps/social_sign_in_internal.py
@@ -27,8 +27,8 @@ def try_sign_out():
 
 
 @when('they enter the correct username and password (social)')
-def sign_in_correct_username_and_password(_):
-    social_sign_in_internal.enter_correct_username()
+def sign_in_correct_username_and_password(context):
+    social_sign_in_internal.enter_correct_username(context.response_user_name)
     social_sign_in_internal.enter_correct_password()
     social_sign_in_internal.click_internal_sign_in_button()
 
@@ -41,8 +41,8 @@ def sign_in_incorrect_username_and_correct_password(_):
 
 
 @when('they enter a correct username and incorrect password (social)')
-def sign_in_correct_username_and_incorrect_password(_):
-    social_sign_in_internal.enter_correct_username()
+def sign_in_correct_username_and_incorrect_password(context):
+    social_sign_in_internal.enter_correct_username(context.response_user_name)
     social_sign_in_internal.enter_incorrect_password()
     social_sign_in_internal.click_internal_sign_in_button()
 
@@ -55,8 +55,8 @@ def sign_in_incorrect_username_and_password(_):
 
 
 @when('they enter a correct username and no password (social)')
-def sign_in_correct_username_and_no_password(_):
-    social_sign_in_internal.enter_correct_username()
+def sign_in_correct_username_and_no_password(context):
+    social_sign_in_internal.enter_correct_username(context.response_user_name)
     social_sign_in_internal.click_internal_sign_in_button()
 
 

--- a/acceptance_tests/features/steps/survey_enrolment.py
+++ b/acceptance_tests/features/steps/survey_enrolment.py
@@ -2,7 +2,7 @@ from behave import given, when, then
 
 from acceptance_tests import browser
 from acceptance_tests.features.pages import enrolment_code, reporting_unit, home
-from common import respondent_utilities
+from acceptance_tests.features.pages.enrolment_code import generate_random_email_address
 
 
 @given("the respondent is ready to enrol in a survey")
@@ -41,7 +41,7 @@ def respondent_enters_enrolment_code(context):
 
 @when('they enter their account details')
 def complete_account_details(context):
-    context.email = respondent_utilities.make_respondent_user_name(str(context.short_name), context.short_name)
+    context.email = generate_random_email_address()
 
     browser.driver.find_element_by_id('first_name').send_keys('FirstName')
     browser.driver.find_element_by_id('last_name').send_keys('LastName')

--- a/acceptance_tests/features/survey_enrolment.feature
+++ b/acceptance_tests/features/survey_enrolment.feature
@@ -1,6 +1,6 @@
 @business
 @standalone
-@fixture.setup.data.default
+@fixture.setup.data.with.unenrolled.respondent.user.and.new.iac
 Feature: As an respondent user
   I need to enrol in a survey
 

--- a/acceptance_tests/features/view_collection_exercise_created_state.feature
+++ b/acceptance_tests/features/view_collection_exercise_created_state.feature
@@ -1,6 +1,6 @@
 @business
 @standalone
-@fixture.setup.data.with.response.user.and.collection.exercise.to.created.status
+@fixture.setup.data.with.internal.user.and.collection.exercise.to.created.status
 Feature: View created state of a collection exercise
   As a Collection Exercise Coordinator
   I need to be able to view the state of a collection exercise when it is 'Created'

--- a/acceptance_tests/features/view_collection_exercise_created_state.feature
+++ b/acceptance_tests/features/view_collection_exercise_created_state.feature
@@ -1,6 +1,6 @@
 @business
 @standalone
-@fixture.setup.data.collection.exercise.created
+@fixture.setup.data.with.response.user.and.collection.exercise.to.created.status
 Feature: View created state of a collection exercise
   As a Collection Exercise Coordinator
   I need to be able to view the state of a collection exercise when it is 'Created'

--- a/acceptance_tests/features/view_response_status.feature
+++ b/acceptance_tests/features/view_response_status.feature
@@ -1,6 +1,6 @@
 @business
 @standalone
-@fixture.setup.data.enrolled.respondent
+@fixture.setup.data.with.enrolled.respondent.user.and.response.user
 Feature: View response status
   As an internal user
   I need to view the case response status for an RU for a specific CE for a specific survey when completed

--- a/acceptance_tests/features/view_response_status.feature
+++ b/acceptance_tests/features/view_response_status.feature
@@ -1,6 +1,6 @@
 @business
 @standalone
-@fixture.setup.data.with.enrolled.respondent.user.and.response.user
+@fixture.setup.data.with.enrolled.respondent.user.and.internal.user
 Feature: View response status
   As an internal user
   I need to view the case response status for an RU for a specific CE for a specific survey when completed

--- a/common/common_utilities.py
+++ b/common/common_utilities.py
@@ -1,4 +1,8 @@
+import signal
 from datetime import datetime
+
+import psutil
+from psutil import NoSuchProcess
 
 
 def create_utc_timestamp():
@@ -30,3 +34,22 @@ def create_behave_tags(tags):
         behave_tags += f' --tags={t}'
 
     return behave_tags
+
+
+def get_child_processes(parent_pid):
+    try:
+        child_processes = psutil.Process(parent_pid).children(recursive=True)
+    except NoSuchProcess as e:
+        return
+
+    return child_processes
+
+def kill_all_processes(children):
+    if not children:
+        return
+
+    try:
+        for process in children:
+            process.send_signal(signal.SIGTERM)
+    except Exception as e:
+        pass

--- a/common/common_utilities.py
+++ b/common/common_utilities.py
@@ -39,10 +39,11 @@ def create_behave_tags(tags):
 def get_child_processes(parent_pid):
     try:
         child_processes = psutil.Process(parent_pid).children(recursive=True)
-    except NoSuchProcess as e:
+    except NoSuchProcess:
         return
 
     return child_processes
+
 
 def kill_all_processes(children):
     if not children:
@@ -51,5 +52,5 @@ def kill_all_processes(children):
     try:
         for process in children:
             process.send_signal(signal.SIGTERM)
-    except Exception as e:
+    except NoSuchProcess:
         pass

--- a/common/internal_utilities.py
+++ b/common/internal_utilities.py
@@ -36,9 +36,9 @@ def generate_access_token(client_id, client_secret, url):
 
 def create_user(access_token, username, password, email, first_name, last_name, url):
     user = {
-        "userName": "{}".format(username),
+        "userName": username,
         "name": {
-            "formatted": "{0} {1}".format(first_name, last_name),
+            "formatted": f'{first_name} {last_name}',
             "givenName": first_name,
             "familyName": last_name
         },
@@ -53,7 +53,7 @@ def create_user(access_token, username, password, email, first_name, last_name, 
 
     headers = {'Content-Type': 'application/json',
                'Accept': 'application/json',
-               'Authorization': 'Bearer {}'.format(access_token)}
+               'Authorization': f'Bearer {access_token}'}
 
     response = requests.post(url, data=json.dumps(user),
                              headers=headers)

--- a/common/internal_utilities.py
+++ b/common/internal_utilities.py
@@ -6,7 +6,7 @@ from common import survey_utilities
 from config import Config
 
 
-def create_response_user_login_account(user_name):
+def create_internal_user_login_account(user_name):
     tokenUrl = f'{Config.UAA_SERVICE}/oauth/token'
 
     access_token = generate_access_token(client_id=Config.UAA_CLIENT_ID, client_secret=Config.UAA_SECRET, url=tokenUrl)

--- a/common/internal_utilities.py
+++ b/common/internal_utilities.py
@@ -25,7 +25,7 @@ def generate_access_token(client_id, client_secret, url):
                'response_type': 'token',
                'token_format': 'opaque'}
 
-    response = requests.post(url.format(url), headers=headers,
+    response = requests.post(url=url, headers=headers,
                              params=payload,
                              auth=(client_id, client_secret))
 

--- a/common/respondent_utilities.py
+++ b/common/respondent_utilities.py
@@ -46,8 +46,8 @@ def enrol_respondent(respondent_id):
     return respondent_id
 
 
-def make_respondent_user_name(left_part, right_part):
-    return survey_utilities.make_email_address(left_part, right_part)
+def make_respondent_user_name(short_name):
+    return survey_utilities.make_email_address(short_name, short_name)
 
 
 def create_respondent_user_login_account(user_name):

--- a/common/response_utilities.py
+++ b/common/response_utilities.py
@@ -1,0 +1,63 @@
+import json
+
+import requests
+
+from common import survey_utilities
+from config import Config
+
+
+def create_response_user_login_account(user_name):
+    tokenUrl = f'{Config.UAA_SERVICE}/oauth/token'
+
+    access_token = generate_access_token(client_id=Config.UAA_CLIENT_ID, client_secret=Config.UAA_SECRET, url=tokenUrl)
+
+    userUrl = f'{Config.UAA_SERVICE}/Users'
+    email = survey_utilities.make_email_address(user_name, user_name)
+
+    return create_user(access_token, user_name, Config.UAA_DEFAULT_USER_PASSWORD, email, user_name, user_name, userUrl)
+
+
+def generate_access_token(client_id, client_secret, url):
+    headers = {'Content-Type': 'application/x-www-form-urlencoded',
+               'Accept': 'application/json'}
+
+    payload = {'grant_type': 'client_credentials',
+               'response_type': 'token',
+               'token_format': 'opaque'}
+
+    response = requests.post(url.format(url), headers=headers,
+                             params=payload,
+                             auth=(client_id, client_secret))
+
+    response.raise_for_status()
+
+    return response.json().get('access_token')
+
+
+def create_user(access_token, username, password, email, first_name, last_name, url):
+    user = {
+        "userName": "{}".format(username),
+        "name": {
+            "formatted": "{0} {1}".format(first_name, last_name),
+            "givenName": first_name,
+            "familyName": last_name
+        },
+        "emails": [{
+            "value": email,
+            "primary": False
+        }],
+        "active": True,
+        "verified": True,
+        "password": password
+    }
+
+    headers = {'Content-Type': 'application/json',
+               'Accept': 'application/json',
+               'Authorization': 'Bearer {}'.format(access_token)}
+
+    response = requests.post(url, data=json.dumps(user),
+                             headers=headers)
+
+    response.raise_for_status()
+
+    return response

--- a/common/survey_utilities.py
+++ b/common/survey_utilities.py
@@ -99,7 +99,7 @@ def create_default_data(context):
     context.long_name = long_name
     context.survey_ref = survey_ref
     context.survey_id = survey_id
-    context.user_name = respondent_utilities.make_respondent_user_name(str(short_name), short_name)
+    context.respondent_user_name = respondent_utilities.make_respondent_user_name(short_name)
 
 
 # General methods
@@ -159,8 +159,7 @@ def create_test_business_collection_exercise(survey_id, period, ru_ref, ce_name,
 
 
 def create_enrolled_respondent_for_the_test_survey(context, generate_new_iac=False):
-    user_name = respondent_utilities.make_respondent_user_name(str(context.short_name),
-                                                               context.short_name)
+    user_name = respondent_utilities.make_respondent_user_name(context.short_name)
 
     context.phone_number = create_phone_number()
 

--- a/config.py
+++ b/config.py
@@ -8,11 +8,14 @@ class Config(object):
     PROTOCOL = os.getenv('PROTOCOL', 'http')
     INFO = '/info'
 
+    # todo delete when all converted
     RESPONDENT_USERNAME = os.getenv('RESPONDENT_USERNAME', 'example@example.com')
 
     RESPONDENT_PASSWORD = os.getenv('RESPONDENT_PASSWORD', 'password')
 
+    #todo delete when all converted
     INTERNAL_USERNAME = os.getenv('INTERNAL_USERNAME', 'uaa_user')
+
     INTERNAL_PASSWORD = os.getenv('INTERNAL_PASSWORD', 'password')
 
     ACTION_SERVICE_HOST = os.getenv('ACTION_SERVICE_HOST', 'localhost')
@@ -93,6 +96,13 @@ class Config(object):
 
     OAUTH_CLIENT_ID = os.getenv('OAUTH_CLIENT_ID', 'ons@ons.gov')
     OAUTH_CLIENT_SECRET = os.getenv('OAUTH_CLIENT_SECRET', 'password')
+
+    UAA_HOST = os.getenv('UAA_HOST', 'localhost')
+    UAA_PORT = os.getenv('UAA_PORT', '9080')
+    UAA_CLIENT_ID = os.getenv('UAA_CLIENT_ID', 'admin')
+    UAA_SECRET = os.getenv('UAA_SECRET', 'admin_secret')
+    UAA_DEFAULT_USER_PASSWORD = os.getenv('UAA_DEFAULT_USER_PASSWORD', 'password')
+    UAA_SERVICE = f'{PROTOCOL}://{UAA_HOST}:{UAA_PORT}'
 
     DATABASE_URI = os.getenv('DATABASE_URI', "postgres://postgres:postgres@localhost:6432/postgres")
     AUTH_DATABASE_URI = os.getenv('AUTH_DATABASE_URI', DATABASE_URI)

--- a/config.py
+++ b/config.py
@@ -13,7 +13,7 @@ class Config(object):
 
     RESPONDENT_PASSWORD = os.getenv('RESPONDENT_PASSWORD', 'password')
 
-    #todo delete when all converted
+    # todo delete when all converted
     INTERNAL_USERNAME = os.getenv('INTERNAL_USERNAME', 'uaa_user')
 
     INTERNAL_PASSWORD = os.getenv('INTERNAL_PASSWORD', 'password')

--- a/run_in_parallel.py
+++ b/run_in_parallel.py
@@ -81,6 +81,8 @@ def _run_scenario(q, feature_scenario, timeout, command_line_args):
 
     cmd = f'behave {command_line_args} --format progress2 {feature} --name \"{scenario}\"'
 
+    out_bytes = None
+
     try:
         check_output(cmd, shell=True, timeout=timeout)
         code = 0
@@ -131,8 +133,9 @@ def run_all_scenarios(scenarios_to_run, process_count, timeout, command_line_arg
 
                 logger.info(
                     f"Processing Feature [{scenario_index}] : [{feature}], Scenario [{scenario}] in [{process_index}]")
-                process_pool[process_index] = Process(target=_run_scenario, args=(
-                    failure_queue, scenarios_to_run[scenario_index], timeout, command_line_args))
+                process_pool[process_index] = Process(target=_run_scenario, args=(failure_queue,
+                                                                                  scenarios_to_run[scenario_index],
+                                                                                  timeout, command_line_args))
                 process_pool[process_index].start()
 
                 scenario_index += 1

--- a/run_in_parallel.py
+++ b/run_in_parallel.py
@@ -17,7 +17,7 @@ from distutils.util import strtobool
 from multiprocessing import Process, Queue
 from subprocess import Popen, PIPE, check_output, CalledProcessError, TimeoutExpired
 
-from common.common_utilities import create_behave_tags
+from common.common_utilities import create_behave_tags, kill_all_processes, get_child_processes
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -163,11 +163,16 @@ def find_matching_features_and_scenarios(tags, acceptance_features_directory):
     cmd = f'behave -d --no-junit --f json --no-summary {tags} {acceptance_features_directory}'
 
     p = Popen(cmd, stdout=PIPE, shell=True)
+    time.sleep(3)
+    child_processes = get_child_processes(p.pid)
+
     out, err = p.communicate()
     try:
         json_all_features = json.loads(out.decode())
     except ValueError:
         json_all_features = []
+
+    kill_all_processes(child_processes)
 
     return json_all_features
 
@@ -199,7 +204,6 @@ def extract_scenarios_to_run(tags, acceptance_features_directory):
 
 
 def print_summary(start_time, end_time, total_scenarios_run, failure_queue):
-
     struct_time = time.strptime(str(end_time - start_time), "%H:%M:%S.%f")
 
     duration = f'{struct_time.tm_hour:02}:{struct_time.tm_min:02}:{struct_time.tm_sec:02}'


### PR DESCRIPTION
# Motivation and Context
Tests that login to response-operations-ui/response-operations-social-ui apps use the same uaa account which can cause problems when running in parallel.

# What has changed
Tests now create their own unique uua account. Also, fixtures have been renamed to improve readability

# How to test?
make acceptance_tests

# Links
[Trello](https://trello.com/c/cXUAjCxj/356-t338-acceptance-tests-uaa-user-per-scenario)
