### PR TITLE
Change collection exercise automatically live

### DIFF
--- a/acceptance_tests/features/steps/unselect_collection_instruments.py
+++ b/acceptance_tests/features/steps/unselect_collection_instruments.py
@@ -6,7 +6,7 @@ from common.browser_utilities import is_text_present_with_retry
 
 @given('the internal user is on the collection exercise details screen with a loaded CI')
 def ce_details_page_with_loaded_ci(_):
-    collection_exercise_details.go_to('Bricks', '201811')
+    collection_exercise_details.go_to('Bricks', '201812')
     collection_exercise_details.load_collection_instrument(
         test_file='resources/collection_instrument_files/064_201803_0001.xlsx')
 


### PR DESCRIPTION
# Motivation and Context
The CI pipeline is broken. It's broken because we are using specific collection exercises, which have specific go-live dates. The `Bricks` survey collection exercise `201811` went live at midnight tonight, which means that the Collection Exercise service will _automatically_ set this collection exercise to be live.

# What has changed
Changed the collection exercise used from November to December. This is a temporary fix to get the pipeline green.

# How to test?
Run the acceptance tests. Check the tests pass.

# Links
Trello: https://trello.com/c/DOsrckW2/585-bug-fix-the-ci-pipeline-failure-due-to-collection-exercise-go-live-date