### PR TITLE
Use new collection exercise from next year

### DIFF
--- a/acceptance_tests/features/steps/unselect_collection_instruments.py
+++ b/acceptance_tests/features/steps/unselect_collection_instruments.py
@@ -6,7 +6,7 @@ from common.browser_utilities import is_text_present_with_retry
 
 @given('the internal user is on the collection exercise details screen with a loaded CI')
 def ce_details_page_with_loaded_ci(_):
-    collection_exercise_details.go_to('Bricks', '201812')
+    collection_exercise_details.go_to('Bricks', '201911')
     collection_exercise_details.load_collection_instrument(
         test_file='resources/collection_instrument_files/064_201803_0001.xlsx')
 


### PR DESCRIPTION
# Motivation and Context
Using Bricks' December 2018 collection exercise didn't work, because another test was using it (which will probably break in a month) so I needed to add a whole load of new collection exercises for 2019, so that I could use one of those.

These are stop-gap fixes to buy us more time, while we refactor the tests so that they don't use static dates and rely upon particular dates, which end up in the past and cause everything to break.

# What has changed
Used a new collection exercise (Bricks November 2019) created by rm-tools PR.

# How to test?
Run the acceptance tests.

# Links
Trello: https://trello.com/c/DOsrckW2/585-bug-fix-the-ci-pipeline-failure-due-to-collection-exercise-go-live-date
Related PR: https://github.com/ONSdigital/rm-tools/pull/30