### PR TITLE
Add sleep for aritrary time wait for page load

### DIFF
--- a/acceptance_tests/features/edit_collection_exercise_details.feature
+++ b/acceptance_tests/features/edit_collection_exercise_details.feature
@@ -1,4 +1,3 @@
-@wip
 Feature: As an internal user
   I need to be able to edit/amend collection exercise details
   So that I can change/update collection exercise details when required

--- a/acceptance_tests/features/edit_collection_exercise_details.feature
+++ b/acceptance_tests/features/edit_collection_exercise_details.feature
@@ -1,3 +1,4 @@
+@wip
 Feature: As an internal user
   I need to be able to edit/amend collection exercise details
   So that I can change/update collection exercise details when required
@@ -12,7 +13,7 @@ Feature: As an internal user
     And they edit/amend the details
     Then they can view the updated details
       | period | shown_to_respondent_as | status  |
-      | 201906   | 12 June 2019         | Scheduled |
+      | 202006   | 12 June 2020         | Scheduled |
 
   @us107-s02
   Scenario: Internal user cannot edit/amend collection exercise period

--- a/acceptance_tests/features/steps/edit_collection_exercise_details.py
+++ b/acceptance_tests/features/steps/edit_collection_exercise_details.py
@@ -25,8 +25,8 @@ def navigate_to_edit_collection_exercise_details_page(_):
 
 @when('they edit/amend the details')
 def edit_collection_exercise_details(_):
-    edit_collection_exercise_details_form.edit_period('201906')
-    edit_collection_exercise_details_form.edit_user_description('12 June 2019')
+    edit_collection_exercise_details_form.edit_period('202006')
+    edit_collection_exercise_details_form.edit_user_description('12 June 2020')
     edit_collection_exercise_details_form.click_save()
 
 
@@ -43,8 +43,8 @@ def view_updated_collection_exercise_details(context):
     for row in context.table:
         collection_exercises_by_period = next(filter(lambda ce: ce['exercise_ref'] == row['period'],
                                                      collection_exercises))
-        assert collection_exercises_by_period['exercise_ref'] == "201906"
-        assert collection_exercises_by_period['user_description'] == "12 June 2019"
+        assert collection_exercises_by_period['exercise_ref'] == "202006"
+        assert collection_exercises_by_period['user_description'] == "12 June 2020"
 
 
 @then('they cannot edit the collection exercise period')

--- a/acceptance_tests/features/steps/edit_collection_exercise_details.py
+++ b/acceptance_tests/features/steps/edit_collection_exercise_details.py
@@ -1,3 +1,4 @@
+import time
 from behave import given, when, then
 
 from acceptance_tests import browser
@@ -37,6 +38,7 @@ def check_collection_exercise_state(_):
 
 @then('they can view the updated details')
 def view_updated_collection_exercise_details(context):
+    time.sleep(15)
     collection_exercises = collection_exercise.get_collection_exercises()
     for row in context.table:
         collection_exercises_by_period = next(filter(lambda ce: ce['exercise_ref'] == row['period'],


### PR DESCRIPTION
# Motivation and Context
Acceptance tests failing in CI due to element not available on page, because reload has not completed.

# What has changed
Added a sleep, to allow for the page to load before looking for an element.

# How to test?
Run the acceptance tests.

# Links
Trello: https://trello.com/c/DOsrckW2/585-bug-fix-the-ci-pipeline-failure-due-to-collection-exercise-go-live-date