### PR TITLE
Edit survey details

### DIFF
--- a/acceptance_tests/features/create_survey.feature
+++ b/acceptance_tests/features/create_survey.feature
@@ -1,6 +1,6 @@
 @business
 @standalone
-@fixture.setup.prepare.data.for.new.survey.with.internal.user
+@fixture.setup.survey.metadata.with.internal.user
 Feature: As an internal user
   I need to be able to create new surveys
   So that new surveys can be handled by SDC

--- a/acceptance_tests/features/create_survey.feature
+++ b/acceptance_tests/features/create_survey.feature
@@ -1,3 +1,5 @@
+@standalone
+@fixture.setup.prepare.data.for.new.survey.with.internal.user
 Feature: As an internal user
   I need to be able to create new surveys
   So that new surveys can be handled by SDC
@@ -6,25 +8,25 @@ Feature: As an internal user
   Given the internal user is already signed in
 
   @us101-s01
-  Scenario Outline: Internal user is able to create a new survey
+  Scenario: Internal user is able to create a new survey
     Given the internal user has entered the create survey URL
-    When they enter the new survey details as reference <survey_id>, title <survey_title>, abbreviation <survey_abbreviation> and legal basis <survey_legal_basis>
-    Then they can view the survey with reference <survey_id>, title <survey_title>, abbreviation <survey_abbreviation> and legal basis <survey_legal_basis>
-
-    Examples: Test survey data
-    | survey_id | survey_title                 | survey_abbreviation | survey_legal_basis           |
-    | 9999      | Test Survey                  | CREATE              | Statistics of Trade Act 1947 |
+    When they enter new survey details with legal basis of 'Statistics of Trade Act 1947'
+    Then they are taken to survey list page
+     And the new survey information is on the page
 
   @us101-s02
-  Scenario Outline: Internal user is not able to create a new survey with a duplicate reference
-    Given the internal user is on the survey list page
-    And the survey with reference <survey_id> already exists
-    When the internal user has entered the create survey URL
-    And they enter the new survey details as reference <survey_id>, title <survey_title>, abbreviation <survey_abbreviation> and legal basis <survey_legal_basis>
-    Then they get an error page with the message 'Survey with ID <survey_id> already exists'
+  Scenario: Internal user is not able to create a new survey with a duplicate short name
+    Given the internal user has entered the create survey URL
+     And they enter new survey details with legal basis of 'Statistics of Trade Act 1947'
+     And the internal user has entered the create survey URL
+    When they enter new survey details with legal basis of 'Statistics of Trade Act 1947'
+    Then they get an error message of 'The survey with Abbreviation {short_name} already exists'
 
-    Examples: Test survey data
-    | survey_id | survey_title                 | survey_abbreviation | survey_legal_basis           |
-    | 9999      | Another Test Survey          | DUPLICATE           | Statistics of Trade Act 1947 |
-
+  @us101-s02
+  Scenario: Internal user is not able to create a new survey with a duplicate reference
+    Given the internal user has entered the create survey URL
+     And they enter new survey details with legal basis of 'Statistics of Trade Act 1947'
+     And the internal user has entered the create survey URL
+    When they enter new survey details with legal basis of 'Statistics of Trade Act 1947' and new short name
+    Then they get an error message of 'Survey with ID {survey_ref} already exists'
 

--- a/acceptance_tests/features/create_survey.feature
+++ b/acceptance_tests/features/create_survey.feature
@@ -1,3 +1,4 @@
+@business
 @standalone
 @fixture.setup.prepare.data.for.new.survey.with.internal.user
 Feature: As an internal user

--- a/acceptance_tests/features/edit_survey_details.feature
+++ b/acceptance_tests/features/edit_survey_details.feature
@@ -1,3 +1,4 @@
+@standalone
 Feature: As an internal user
   I need to be able to edit/amend survey details
   So that I can change/update survey details when required
@@ -5,13 +6,11 @@ Feature: As an internal user
   Background: Internal user is already signed in
   Given the internal user is already signed in
 
+  @fixture.setup.data.create_survey
   @us106-s01
   Scenario: Internal user is able to edit/amend survey details
     Given the internal user is on the survey list page
-    When they request to edit/amend a surveys details
+    When they request to edit/amend a specific surveys details
     And they edit/amend the survey details
-    Then they can view the updated survey details
-      | survey_id | survey_title                 | survey_abbreviation | survey_legal_basis   |
-      | 199       | National Balance Sheet 2.0   | NBS_2.0             | Voluntary Not Stated |
-    And they request to reset survey details
-    Then the data is reset
+    Then the survey details match the updated values
+

--- a/acceptance_tests/features/edit_survey_details.feature
+++ b/acceptance_tests/features/edit_survey_details.feature
@@ -1,3 +1,4 @@
+@business
 @standalone
 Feature: As an internal user
   I need to be able to edit/amend survey details
@@ -6,7 +7,7 @@ Feature: As an internal user
   Background: Internal user is already signed in
   Given the internal user is already signed in
 
-  @fixture.setup.data.create.new.survey.with.internal.user
+  @fixture.setup.data.survey.with.internal.user
   @us106-s01
   Scenario: Internal user is able to edit/amend survey details
     Given the internal user is on the survey list page

--- a/acceptance_tests/features/edit_survey_details.feature
+++ b/acceptance_tests/features/edit_survey_details.feature
@@ -11,6 +11,6 @@ Feature: As an internal user
   Scenario: Internal user is able to edit/amend survey details
     Given the internal user is on the survey list page
     When they request to edit/amend a specific surveys details
-    And they edit/amend the survey details
+      And they edit/amend the survey details
     Then the survey details match the updated values
 

--- a/acceptance_tests/features/edit_survey_details.feature
+++ b/acceptance_tests/features/edit_survey_details.feature
@@ -6,7 +6,7 @@ Feature: As an internal user
   Background: Internal user is already signed in
   Given the internal user is already signed in
 
-  @fixture.setup.data.create_survey
+  @fixture.setup.data.create.new.survey.with.internal.user
   @us106-s01
   Scenario: Internal user is able to edit/amend survey details
     Given the internal user is on the survey list page

--- a/acceptance_tests/features/environment.py
+++ b/acceptance_tests/features/environment.py
@@ -5,7 +5,7 @@ from behave import use_fixture
 from structlog import wrap_logger
 
 from acceptance_tests import browser
-from acceptance_tests.features.fixtures import setup_data_create_new_survey_with_internal_user, \
+from acceptance_tests.features.fixtures import setup_data_survey_with_internal_user, \
                setup_data_with_2_enrolled_respondent_users_and_internal_user, \
                setup_data_with_enrolled_respondent_user_and_internal_user, \
                setup_data_with_enrolled_respondent_user_and_internal_user_and_new_iac_and_collection_exercise_to_live,\
@@ -36,8 +36,8 @@ timings = {}
 fixture_scenario_registry = {
     'fixture.setup.prepare.data.for.new.survey.with.internal.user':
         setup_prepare_data_for_new_survey_with_internal_user,
-    'fixture.setup.data.create.new.survey.with.internal.user':
-        setup_data_create_new_survey_with_internal_user,
+    'fixture.setup.data.survey.with.internal.user':
+        setup_data_survey_with_internal_user,
     'fixture.setup.with.internal.user':
         setup_with_internal_user,
     'fixture.setup.data.with.internal.user':

--- a/acceptance_tests/features/environment.py
+++ b/acceptance_tests/features/environment.py
@@ -8,7 +8,7 @@ from acceptance_tests import browser
 from acceptance_tests.features.fixtures import setup_data_new_survey, \
                setup_data_with_2_enrolled_respondent_users_and_internal_user, \
                setup_data_with_enrolled_respondent_user_and_internal_user, \
-               setup_data_with_enrolled_respondent_user_and_internal_user_and_new_iac_and_collection_exercise_to_live, \
+               setup_data_with_enrolled_respondent_user_and_internal_user_and_new_iac_and_collection_exercise_to_live,\
                setup_with_internal_user, \
                setup_data_with_internal_user_and_social_collection_exercise_to_closed_status, \
                setup_data_with_internal_user_and_collection_exercise_to_created_status, \

--- a/acceptance_tests/features/environment.py
+++ b/acceptance_tests/features/environment.py
@@ -5,7 +5,7 @@ from behave import use_fixture
 from structlog import wrap_logger
 
 from acceptance_tests import browser
-from acceptance_tests.features.fixtures import setup_data_new_survey, \
+from acceptance_tests.features.fixtures import setup_data_create_new_survey_with_internal_user, \
                setup_data_with_2_enrolled_respondent_users_and_internal_user, \
                setup_data_with_enrolled_respondent_user_and_internal_user, \
                setup_data_with_enrolled_respondent_user_and_internal_user_and_new_iac_and_collection_exercise_to_live,\
@@ -16,7 +16,8 @@ from acceptance_tests.features.fixtures import setup_data_new_survey, \
                setup_data_with_unenrolled_respondent_user, \
                setup_data_with_unenrolled_respondent_user_and_internal_user, \
                setup_data_with_unenrolled_respondent_user_and_new_iac, \
-               setup_data_with_unenrolled_respondent_user_and_new_iac_and_collection_exercise_to_live
+               setup_data_with_unenrolled_respondent_user_and_new_iac_and_collection_exercise_to_live, \
+               setup_prepare_data_for_new_survey_with_internal_user
 
 from common import survey_utilities
 from config import Config
@@ -32,10 +33,11 @@ logger = wrap_logger(getLogger(__name__))
 
 timings = {}
 
-
 fixture_scenario_registry = {
-    'fixture.setup.data.create_survey':
-        setup_data_new_survey,
+    'fixture.setup.prepare.data.for.new.survey.with.internal.user':
+        setup_prepare_data_for_new_survey_with_internal_user,
+    'fixture.setup.data.create.new.survey.with.internal.user':
+        setup_data_create_new_survey_with_internal_user,
     'fixture.setup.with.internal.user':
         setup_with_internal_user,
     'fixture.setup.data.with.internal.user':

--- a/acceptance_tests/features/environment.py
+++ b/acceptance_tests/features/environment.py
@@ -17,7 +17,7 @@ from acceptance_tests.features.fixtures import setup_data_survey_with_internal_u
                setup_data_with_unenrolled_respondent_user_and_internal_user, \
                setup_data_with_unenrolled_respondent_user_and_new_iac, \
                setup_data_with_unenrolled_respondent_user_and_new_iac_and_collection_exercise_to_live, \
-               setup_prepare_data_for_new_survey_with_internal_user
+               setup_survey_metadata_with_internal_user
 
 from common import survey_utilities
 from config import Config
@@ -34,8 +34,8 @@ logger = wrap_logger(getLogger(__name__))
 timings = {}
 
 fixture_scenario_registry = {
-    'fixture.setup.prepare.data.for.new.survey.with.internal.user':
-        setup_prepare_data_for_new_survey_with_internal_user,
+    'fixture.setup.survey.metadata.with.internal.user':
+        setup_survey_metadata_with_internal_user,
     'fixture.setup.data.survey.with.internal.user':
         setup_data_survey_with_internal_user,
     'fixture.setup.with.internal.user':

--- a/acceptance_tests/features/environment.py
+++ b/acceptance_tests/features/environment.py
@@ -6,6 +6,7 @@ from structlog import wrap_logger
 
 from acceptance_tests import browser
 from acceptance_tests.features.fixtures import \
+    setup_data_new_survey, \
     setup_data_with_enrolled_respondent_user_and_internal_user, \
     setup_data_with_unenrolled_respondent_user, \
     setup_data_with_unenrolled_respondent_user_and_new_iac_and_collection_exercise_to_live, \
@@ -14,8 +15,9 @@ from acceptance_tests.features.fixtures import \
     setup_data_with_2_enrolled_respondent_users_and_internal_user, \
     setup_data_with_internal_user_and_social_collection_exercise_to_closed_status, \
     setup_data_with_internal_user_and_collection_exercise_to_created_status, setup_data_with_response_user, \
-    setup_with_internal_user, \
-    setup_data_with_unenrolled_respondent_user_and_internal_user
+    setup_data_with_unenrolled_respondent_user_and_internal_user, \
+    setup_with_internal_user
+
 from common import survey_utilities
 from config import Config
 from exceptions import MissingFixtureError
@@ -32,6 +34,8 @@ timings = {}
 
 
 fixture_scenario_registry = {
+    'fixture.setup.data.create_survey':
+        setup_data_new_survey,
     'fixture.setup.with.internal.user':
         setup_with_internal_user,
     'fixture.setup.data.with.internal.user':

--- a/acceptance_tests/features/environment.py
+++ b/acceptance_tests/features/environment.py
@@ -5,18 +5,18 @@ from behave import use_fixture
 from structlog import wrap_logger
 
 from acceptance_tests import browser
-from acceptance_tests.features.fixtures import \
-    setup_data_new_survey, \
-    setup_data_with_enrolled_respondent_user_and_internal_user, \
-    setup_data_with_unenrolled_respondent_user, \
-    setup_data_with_unenrolled_respondent_user_and_new_iac_and_collection_exercise_to_live, \
-    setup_data_with_unenrolled_respondent_user_and_new_iac, \
-    setup_data_with_enrolled_respondent_user_and_internal_user_and_new_iac_and_collection_exercise_to_live, \
-    setup_data_with_2_enrolled_respondent_users_and_internal_user, \
-    setup_data_with_internal_user_and_social_collection_exercise_to_closed_status, \
-    setup_data_with_internal_user_and_collection_exercise_to_created_status, setup_data_with_response_user, \
-    setup_data_with_unenrolled_respondent_user_and_internal_user, \
-    setup_with_internal_user
+from acceptance_tests.features.fixtures import setup_data_new_survey, \
+               setup_data_with_2_enrolled_respondent_users_and_internal_user, \
+               setup_data_with_enrolled_respondent_user_and_internal_user, \
+               setup_data_with_enrolled_respondent_user_and_internal_user_and_new_iac_and_collection_exercise_to_live, \
+               setup_with_internal_user, \
+               setup_data_with_internal_user_and_social_collection_exercise_to_closed_status, \
+               setup_data_with_internal_user_and_collection_exercise_to_created_status, \
+               setup_data_with_response_user, \
+               setup_data_with_unenrolled_respondent_user, \
+               setup_data_with_unenrolled_respondent_user_and_internal_user, \
+               setup_data_with_unenrolled_respondent_user_and_new_iac, \
+               setup_data_with_unenrolled_respondent_user_and_new_iac_and_collection_exercise_to_live
 
 from common import survey_utilities
 from config import Config

--- a/acceptance_tests/features/fixtures.py
+++ b/acceptance_tests/features/fixtures.py
@@ -2,10 +2,17 @@ from behave import fixture
 
 from acceptance_tests.features.pages.inbox_internal import after_scenario_cleanup
 from common import internal_utilities
-from common.survey_utilities import create_default_data, create_enrolled_respondent_for_the_test_survey, \
-    COLLECTION_EXERCISE_STATUS_LIVE, create_unenrolled_respondent, create_data_for_survey, create_test_survey, \
-    create_data_for_collection_exercise, create_survey_reference, \
-    create_test_business_collection_exercise, COLLECTION_EXERCISE_STATUS_CREATED, create_ru_reference
+from common.survey_utilities import COLLECTION_EXERCISE_STATUS_CREATED, \
+                                    COLLECTION_EXERCISE_STATUS_LIVE, \
+                                    create_data_for_collection_exercise, \
+                                    create_data_for_survey, \
+                                    create_default_data, \
+                                    create_enrolled_respondent_for_the_test_survey, \
+                                    create_ru_reference, \
+                                    create_survey_reference, \
+                                    create_test_business_collection_exercise, \
+                                    create_test_survey, \
+                                    create_unenrolled_respondent
 from controllers import collection_exercise_controller
 
 

--- a/acceptance_tests/features/fixtures.py
+++ b/acceptance_tests/features/fixtures.py
@@ -16,14 +16,6 @@ from common.survey_utilities import COLLECTION_EXERCISE_STATUS_CREATED, \
 from controllers import collection_exercise_controller
 
 
-def setup_data_create_new_survey(context):
-    """ Creates test survey """
-    setup_prepare_data_for_new_survey(context)
-    survey_id = create_test_survey(context.long_name, context.short_name, context.survey_ref, context.survey_type,
-                                   context.legal_basis)
-    context.survey_id = survey_id
-
-
 def setup_prepare_data_for_new_survey(context):
     survey_data = create_data_for_survey(context)
 
@@ -186,13 +178,13 @@ def create_internal_user(context):
     internal_utilities.create_internal_user_login_account(context.internal_user_name)
 
 
-def setup_prepare_data_for_new_survey_with_internal_user(context):
+def setup_survey_metadata_with_internal_user(context):
     setup_with_internal_user(context)
     setup_prepare_data_for_new_survey(context)
 
 
 def setup_data_survey_with_internal_user(context):
-    setup_prepare_data_for_new_survey_with_internal_user(context)
+    setup_survey_metadata_with_internal_user(context)
     survey_id = create_test_survey(context.long_name, context.short_name, context.survey_ref, context.survey_type,
                                    context.legal_basis)
     context.survey_id = survey_id

--- a/acceptance_tests/features/fixtures.py
+++ b/acceptance_tests/features/fixtures.py
@@ -191,7 +191,7 @@ def setup_prepare_data_for_new_survey_with_internal_user(context):
     setup_prepare_data_for_new_survey(context)
 
 
-def setup_data_create_new_survey_with_internal_user(context):
+def setup_data_survey_with_internal_user(context):
     setup_prepare_data_for_new_survey_with_internal_user(context)
     survey_id = create_test_survey(context.long_name, context.short_name, context.survey_ref, context.survey_type,
                                    context.legal_basis)

--- a/acceptance_tests/features/fixtures.py
+++ b/acceptance_tests/features/fixtures.py
@@ -4,9 +4,30 @@ from acceptance_tests.features.pages.inbox_internal import after_scenario_cleanu
 from common import internal_utilities
 from common.survey_utilities import create_default_data, create_enrolled_respondent_for_the_test_survey, \
     COLLECTION_EXERCISE_STATUS_LIVE, create_unenrolled_respondent, create_data_for_survey, create_test_survey, \
-    create_data_for_collection_exercise, \
+    create_data_for_collection_exercise, create_survey_reference, \
     create_test_business_collection_exercise, COLLECTION_EXERCISE_STATUS_CREATED, create_ru_reference
 from controllers import collection_exercise_controller
+
+
+@fixture
+def setup_data_new_survey(context):
+    """ Creates test survey """
+    survey_data = create_data_for_survey(context)
+    period = survey_data['period']
+    short_name = survey_data['short_name']
+    legal_basis = survey_data['legal_basis']
+    long_name = survey_data['long_name']
+
+    survey_type = context.survey_type
+
+    survey_ref = create_survey_reference()
+
+    survey_id = create_test_survey(long_name, short_name, survey_ref, survey_type, legal_basis)
+
+    context.survey_id = survey_id
+    context.short_name = short_name
+    context.period = period
+    context.survey_ref = survey_ref
 
 
 @fixture

--- a/acceptance_tests/features/fixtures.py
+++ b/acceptance_tests/features/fixtures.py
@@ -16,25 +16,22 @@ from common.survey_utilities import COLLECTION_EXERCISE_STATUS_CREATED, \
 from controllers import collection_exercise_controller
 
 
-@fixture
-def setup_data_new_survey(context):
+def setup_data_create_new_survey(context):
     """ Creates test survey """
-    survey_data = create_data_for_survey(context)
-    period = survey_data['period']
-    short_name = survey_data['short_name']
-    legal_basis = survey_data['legal_basis']
-    long_name = survey_data['long_name']
-
-    survey_type = context.survey_type
-
-    survey_ref = create_survey_reference()
-
-    survey_id = create_test_survey(long_name, short_name, survey_ref, survey_type, legal_basis)
-
+    setup_prepare_data_for_new_survey(context)
+    survey_id = create_test_survey(context.long_name, context.short_name, context.survey_ref, context.survey_type,
+                                   context.legal_basis)
     context.survey_id = survey_id
-    context.short_name = short_name
-    context.period = period
-    context.survey_ref = survey_ref
+
+
+def setup_prepare_data_for_new_survey(context):
+    survey_data = create_data_for_survey(context)
+
+    context.long_name = survey_data['long_name']
+    context.short_name = survey_data['short_name']
+    context.period = survey_data['period']
+    context.survey_ref = create_survey_reference()
+    context.legal_basis = survey_data['legal_basis']
 
 
 @fixture
@@ -187,3 +184,15 @@ def create_internal_user(context):
     context.internal_user_name = create_ru_reference()
 
     internal_utilities.create_internal_user_login_account(context.internal_user_name)
+
+
+def setup_prepare_data_for_new_survey_with_internal_user(context):
+    setup_with_internal_user(context)
+    setup_prepare_data_for_new_survey(context)
+
+
+def setup_data_create_new_survey_with_internal_user(context):
+    setup_prepare_data_for_new_survey_with_internal_user(context)
+    survey_id = create_test_survey(context.long_name, context.short_name, context.survey_ref, context.survey_type,
+                                   context.legal_basis)
+    context.survey_id = survey_id

--- a/acceptance_tests/features/steps/create_survey.py
+++ b/acceptance_tests/features/steps/create_survey.py
@@ -20,32 +20,10 @@ def check_user_on_survey_create_page(_):
                                                                                             expected_title)
 
 
-@given('the survey with reference {survey_id} already exists')
-def check_survey_exists(_, survey_id):
-    survey.go_to()
-    surveys = survey.get_surveys()
-
-    matching = [s for s in surveys if s['id'] == survey_id]
-
-    assert len(matching) > 0, "Cannot find the survey with reference {}".format(survey_id)
-
-
-@when('they enter the new survey details as reference {survey_id}, title {survey_title}, abbreviation {'
-      'survey_abbreviation} and legal basis {survey_legal_basis}')
-def create_survey_details(_, survey_id, survey_title, survey_abbreviation, survey_legal_basis):
-    create_survey_form.edit_survey_ref(survey_id)
-    create_survey_form.edit_short_name(survey_abbreviation)
-    create_survey_form.edit_long_name(survey_title)
-    create_survey_form.edit_legal_basis(survey_legal_basis)
-
-    create_survey_form.click_save()
-
-
 @given("they enter new survey details with legal basis of '{legal_basis}'")
 @when("they enter new survey details with legal basis of '{legal_basis}'")
 def create_new_survey_details(context, legal_basis):
 
-    # context.survey_ref = context.survey_ref[-6:]
     create_survey_form.edit_survey_ref(context.survey_ref)
     create_survey_form.edit_short_name(context.short_name)
     create_survey_form.edit_long_name(context.long_name)
@@ -87,38 +65,6 @@ def the_new_survey_information_is_on_the_page(context):
         format(matching_survey['short_name'], context.short_name)
     assert matching_survey['legal_basis'] == context.legal_basis, "Unexpected survey legal basis {} ({} expected)".\
         format(matching_survey['legal_basis'], context.legal_basis)
-
-
-@then('they can view the survey with reference {survey_id}, title {survey_title}, abbreviation {survey_abbreviation} '
-      'and legal basis {survey_legal_basis}')
-def view_survey_details(_, survey_id, survey_title, survey_abbreviation, survey_legal_basis):
-    expected_title = "Surveys | Survey Data Collection"
-    assert expected_title in browser.title, "Unexpected page title {} ({} expected) - possible error: {}".format(
-        browser.title, expected_title, create_survey_form.save_error())
-    surveys = survey.get_surveys()
-
-    matching = [s for s in surveys if s['id'] == survey_id]
-    assert len(matching) > 0, "Failed to find survey with ref {}".format(survey_id)
-
-    # We've checked it's length is greater than zero so this is safe
-    survey_by_id = matching[0]
-
-    assert survey_by_id['id'] == survey_id, "Unexpected survey id {} ({} expected)".format(survey_by_id['id'],
-                                                                                           survey_id)
-    assert survey_by_id['name'] == survey_title, "Unexpected survey name {} ({} expected)".format(survey_by_id['id'],
-                                                                                                  survey_title)
-    assert survey_by_id['short_name'] == survey_abbreviation, "Unexpected survey id {} ({} expected)".format(
-        survey_by_id['short_name'], survey_abbreviation)
-    assert survey_by_id['legal_basis'] == survey_legal_basis, "Unexpected survey legal basis {} ({} expected)".format(
-        survey_by_id['legal_basis'], survey_legal_basis)
-
-
-@then('they get an error page with the message \'{expected_error_message}\'')
-def check_error_page(_, expected_error_message):
-    actual_error_message = create_survey_form.save_error()
-
-    assert expected_error_message == actual_error_message, \
-        "Expected error message '{}' not found (found '{}'".format(expected_error_message, actual_error_message)
 
 
 @then("they get an error message of '{match_string}'")

--- a/acceptance_tests/features/steps/create_survey.py
+++ b/acceptance_tests/features/steps/create_survey.py
@@ -5,7 +5,8 @@ from structlog import wrap_logger
 
 from acceptance_tests import browser
 from acceptance_tests.features.pages import create_survey_form, survey
-
+from common.string_utilities import substitute_context_values
+from common.survey_utilities import create_ru_reference
 
 logger = wrap_logger(logging.getLogger(__name__))
 
@@ -40,6 +41,54 @@ def create_survey_details(_, survey_id, survey_title, survey_abbreviation, surve
     create_survey_form.click_save()
 
 
+@given("they enter new survey details with legal basis of '{legal_basis}'")
+@when("they enter new survey details with legal basis of '{legal_basis}'")
+def create_new_survey_details(context, legal_basis):
+
+    # context.survey_ref = context.survey_ref[-6:]
+    create_survey_form.edit_survey_ref(context.survey_ref)
+    create_survey_form.edit_short_name(context.short_name)
+    create_survey_form.edit_long_name(context.long_name)
+
+    create_survey_form.edit_legal_basis(legal_basis)
+    context.legal_basis = legal_basis
+    create_survey_form.click_save()
+
+
+@given("they enter new survey details with legal basis of '{legal_basis}' and new short name")
+@when("they enter new survey details with legal basis of '{legal_basis}' and new short name")
+def create_new_survey_details_with_new_short_name(context, legal_basis):
+    context.short_name = create_ru_reference()
+    create_new_survey_details(context, legal_basis)
+
+
+@then('they are taken to survey list page')
+def they_are_taken_to_survey_list_page(context):
+    expected_title = "Surveys | Survey Data Collection"
+    assert expected_title in browser.title, "Unexpected page title {} ({} expected) - possible error: {}".format(
+        browser.title, expected_title, create_survey_form.save_error())
+
+
+@then('the new survey information is on the page')
+def the_new_survey_information_is_on_the_page(context):
+    surveys = survey.get_surveys()
+
+    matching = [s for s in surveys if s['id'] == context.survey_ref]
+    assert len(matching) > 0, "Failed to find survey with ref {}".format(context.survey_id)
+
+    # We've checked it's length is greater than zero so this is safe
+    matching_survey = matching[0]
+
+    assert matching_survey['id'] == context.survey_ref, "Unexpected survey id {} ({} expected)".\
+        format(matching_survey['id'], context.survey_ref)
+    assert matching_survey['name'] == context.long_name, "Unexpected survey name {} ({} expected)".\
+        format(matching_survey['id'], context.long_name)
+    assert matching_survey['short_name'] == context.short_name, "Unexpected survey id {} ({} expected)".\
+        format(matching_survey['short_name'], context.short_name)
+    assert matching_survey['legal_basis'] == context.legal_basis, "Unexpected survey legal basis {} ({} expected)".\
+        format(matching_survey['legal_basis'], context.legal_basis)
+
+
 @then('they can view the survey with reference {survey_id}, title {survey_title}, abbreviation {survey_abbreviation} '
       'and legal basis {survey_legal_basis}')
 def view_survey_details(_, survey_id, survey_title, survey_abbreviation, survey_legal_basis):
@@ -70,3 +119,11 @@ def check_error_page(_, expected_error_message):
 
     assert expected_error_message == actual_error_message, \
         "Expected error message '{}' not found (found '{}'".format(expected_error_message, actual_error_message)
+
+
+@then("they get an error message of '{match_string}'")
+def check_error_message_matches(context, match_string):
+    actual_error_message = create_survey_form.save_error()
+    expected_error_message = substitute_context_values(context, match_string)
+    assert expected_error_message == actual_error_message, \
+        "expected:{expected_error_message} does not match {actual_error_message}"

--- a/acceptance_tests/features/steps/edit_survey_details.py
+++ b/acceptance_tests/features/steps/edit_survey_details.py
@@ -43,4 +43,3 @@ def survey_survey_details_match_updated_values(context):
     test_survey = next(filter(lambda s: s['id'] == context.survey_ref, surveys))
     assert test_survey['short_name'] == context.expected_short_name
     assert test_survey['name'] == context.expected_long_name
-

--- a/acceptance_tests/features/steps/edit_survey_details.py
+++ b/acceptance_tests/features/steps/edit_survey_details.py
@@ -2,6 +2,7 @@ from behave import given, when, then
 
 from acceptance_tests import browser
 from acceptance_tests.features.pages import edit_survey_details_form, survey
+from common.survey_utilities import create_data_for_survey
 
 
 @given('the internal user is on the survey list page')
@@ -15,36 +16,31 @@ def user_navigates_to_edit_survey_details_page_for_nbs(_):
     survey.click_edit_survey_details_button()
 
 
+@when('they request to edit/amend a specific surveys details')
+def user_clicks_to_edit_survey_details_page_for_survey_in_context(context):
+    btn_id = f"edit-survey-details-{context.survey_ref}"
+    browser.click_link_by_id(btn_id)
+
+
 @when('they edit/amend the survey details')
-def edit_survey_details(_):
-    edit_survey_details_form.edit_short_name('NBS_2.0')
-    edit_survey_details_form.edit_long_name('National Balance Sheet 2.0')
+def edit_survey_details(context):
+    survey_data = create_data_for_survey(context)
+    short_name = survey_data['short_name']
+    long_name = survey_data['long_name']
+
+    edit_survey_details_form.edit_short_name(short_name)
+    edit_survey_details_form.edit_long_name(long_name)
+
+    context.expected_short_name = short_name
+    context.expected_long_name = long_name
+
     edit_survey_details_form.click_save()
 
 
-@then('they can view the updated survey details')
-def view_updated_survey_details(context):
+@then('the survey details match the updated values')
+def survey_survey_details_match_updated_values(context):
     surveys = survey.get_surveys()
+    test_survey = next(filter(lambda s: s['id'] == context.survey_ref, surveys))
+    assert test_survey['short_name'] == context.expected_short_name
+    assert test_survey['name'] == context.expected_long_name
 
-    for row in context.table:
-        survey_by_id = next(filter(lambda s: s['id'] == row['survey_id'], surveys))
-        assert survey_by_id['id'] == "199"
-        assert survey_by_id['name'] == "National Balance Sheet 2.0"
-        assert survey_by_id['short_name'] == "NBS_2.0"
-        assert survey_by_id['legal_basis'] == "Voluntary Not Stated"
-
-# This is only a temporary measure to reset the data back to the way it initially was to allow other features to
-# pass correctly
-
-
-@then('they request to reset survey details')
-@when('they request to reset survey details')
-def reset_survey_details_page_for_nbs(_):
-    survey.click_edit_survey_details_button()
-
-
-@then('the data is reset')
-def reset_survey_details(_):
-    edit_survey_details_form.edit_short_name('NBS')
-    edit_survey_details_form.edit_long_name('National Balance Sheet')
-    edit_survey_details_form.click_save()

--- a/acceptance_tests/features/steps/edit_survey_details.py
+++ b/acceptance_tests/features/steps/edit_survey_details.py
@@ -11,11 +11,6 @@ def check_user_on_surveys_page(_):
     assert "Surveys | Survey Data Collection" in browser.title
 
 
-@when('they request to edit/amend a surveys details')
-def user_navigates_to_edit_survey_details_page_for_nbs(_):
-    survey.click_edit_survey_details_button()
-
-
 @when('they request to edit/amend a specific surveys details')
 def user_clicks_to_edit_survey_details_page_for_survey_in_context(context):
     btn_id = f"edit-survey-details-{context.survey_ref}"

--- a/common/string_utilities.py
+++ b/common/string_utilities.py
@@ -1,0 +1,18 @@
+import nose
+import re
+
+
+def substitute_context_values(context, raw_string):
+    """scans the raw string looking for {context.value} or {value}, replaces each instance with the corresponding
+    value from context. Will ignore spaces after '{' and before '}'
+     """
+    new_string = raw_string.replace('{context.', '{')
+    matches = re.findall('{[\sa-zA-Z0-9_]+}', raw_string)
+
+    for match_str in matches:
+        context_attr = match_str.replace('{', '').replace('}', '').strip()
+        replacement = getattr(context, context_attr, None)
+        nose.tools.assert_is_not_none(replacement, f"Unable to to find value for {context_attr} on context object")
+        new_string = re.sub(match_str, replacement, new_string)
+
+    return new_string

--- a/common/survey_utilities.py
+++ b/common/survey_utilities.py
@@ -27,7 +27,7 @@ RU_REFERENCE_END = 59999999999
 
 SURVEY_REFERENCE_PREFIX = '9'
 SURVEY_REFERENCE_START = 1001
-SURVEY_REFERENCE_END = 999999
+SURVEY_REFERENCE_END = 99999
 
 TELEPHONE_NUMBER_START = 0
 TELEPHONE_NUMBER_END = 99999999999
@@ -212,7 +212,7 @@ def make_email_address(local_part=None, domain=None):
     if not domain:
         domain = local_part
 
-    return concatenate_strings(concatenate_strings(local_part, '@'), concatenate_strings(domain, '.com'))
+    return f"{local_part}@{domain}.com"
 
 
 def format_survey_name(survey_name_in, social_survey, max_field_length):

--- a/common/survey_utilities.py
+++ b/common/survey_utilities.py
@@ -69,7 +69,6 @@ def create_data_for_survey(context):
 
 def create_data_for_collection_exercise():
     """ Data used for creating a Collection Exercise """
-
     return {
         'survey_ref': create_survey_reference()
     }

--- a/common/survey_utilities.py
+++ b/common/survey_utilities.py
@@ -3,10 +3,17 @@ from logging import getLogger
 from random import randint
 
 from structlog import wrap_logger
-
-import common.collection_exercise_utilities
-from common import common_utilities
-from common import respondent_utilities
+from common.collection_exercise_utilities import execute_collection_exercises, \
+                                                 find_case_by_enrolment_code, \
+                                                 generate_collection_exercise_dates_from_period, \
+                                                 generate_new_enrolment_code, \
+                                                 make_user_description
+from common.common_utilities import concatenate_strings, compact_string, create_utc_timestamp
+from common.respondent_utilities import create_respondent, \
+                                        create_respondent_user_login_account, \
+                                        make_respondent_user_name, \
+                                        register_respondent, \
+                                        unenrol_respondent_in_survey
 from config import Config
 from controllers import collection_exercise_controller, survey_controller
 
@@ -34,9 +41,9 @@ logger = wrap_logger(getLogger(__name__))
 # Sequential methods
 
 def setup_sequential_data_for_test():
-    common.collection_exercise_utilities.execute_collection_exercises()
-    common.respondent_utilities.register_respondent(survey_id='cb8accda-6118-4d3b-85a3-149e28960c54', period='201801',
-                                                    username=Config.RESPONDENT_USERNAME, ru_ref=49900000001)
+    execute_collection_exercises()
+    register_respondent(survey_id='cb8accda-6118-4d3b-85a3-149e28960c54', period='201801',
+                        username=Config.RESPONDENT_USERNAME, ru_ref=49900000001)
 
 
 # Parallel methods
@@ -99,7 +106,7 @@ def create_default_data(context):
     context.long_name = long_name
     context.survey_ref = survey_ref
     context.survey_id = survey_id
-    context.respondent_user_name = respondent_utilities.make_respondent_user_name(short_name)
+    context.respondent_user_name = make_respondent_user_name(short_name)
 
 
 # General methods
@@ -124,9 +131,8 @@ def create_test_social_collection_exercise(context, survey_id, period, ru_ref, c
 
     logger.debug('Creating Social Collection Exercise', survey_id=survey_id, period=period)
 
-    user_description = common.collection_exercise_utilities.make_user_description(ce_name,
-                                                                                  is_social_survey(survey_type), 50)
-    dates = common.collection_exercise_utilities.generate_collection_exercise_dates_from_period(period)
+    user_description = make_user_description(ce_name, is_social_survey(survey_type), 50)
+    dates = generate_collection_exercise_dates_from_period(period)
 
     iac = collection_exercise_controller.create_and_execute_social_collection_exercise(context, survey_id, period,
                                                                                        user_description, dates,
@@ -143,9 +149,8 @@ def create_test_business_collection_exercise(survey_id, period, ru_ref, ce_name,
 
     logger.debug('Creating Business Collection Exercise', survey_id=survey_id, period=period)
 
-    user_description = common.collection_exercise_utilities.make_user_description(ce_name,
-                                                                                  is_social_survey(survey_type), 50)
-    dates = common.collection_exercise_utilities.generate_collection_exercise_dates_from_period(period)
+    user_description = make_user_description(ce_name, is_social_survey(survey_type), 50)
+    dates = generate_collection_exercise_dates_from_period(period)
 
     iac = collection_exercise_controller.create_and_execute_collection_exercise_with_unique_sample(survey_id, period,
                                                                                                    user_description,
@@ -159,23 +164,22 @@ def create_test_business_collection_exercise(survey_id, period, ru_ref, ce_name,
 
 
 def create_enrolled_respondent_for_the_test_survey(context, generate_new_iac=False):
-    user_name = respondent_utilities.make_respondent_user_name(context.short_name)
+    user_name = make_respondent_user_name(context.short_name)
 
     context.phone_number = create_phone_number()
 
-    respondent_utilities.create_respondent(user_name=user_name, enrolment_code=context.iac,
-                                           phone_number=context.phone_number)
-    respondent_utilities.create_respondent_user_login_account(user_name)
+    create_respondent(user_name=user_name, enrolment_code=context.iac, phone_number=context.phone_number)
+    create_respondent_user_login_account(user_name)
 
     if generate_new_iac:
-        case = common.collection_exercise_utilities.find_case_by_enrolment_code(context.iac)
-        context.iac = common.collection_exercise_utilities.generate_new_enrolment_code(case['id'], case['partyId'])
+        case = find_case_by_enrolment_code(context.iac)
+        context.iac = generate_new_enrolment_code(case['id'], case['partyId'])
 
 
 def create_unenrolled_respondent(context, generate_new_iac=False):
     create_enrolled_respondent_for_the_test_survey(context, generate_new_iac)
 
-    respondent_utilities.unenrol_respondent_in_survey(context.survey_id)
+    unenrol_respondent_in_survey(context.survey_id)
 
 
 def is_social_survey(survey_type):
@@ -195,7 +199,7 @@ def create_social_survey_period(period_offset_days=0):
 
 
 def format_period(period_year, period_month):
-    return common_utilities.concatenate_strings(str(period_year), str(period_month).zfill(2))
+    return concatenate_strings(str(period_year), str(period_month).zfill(2))
 
 
 def create_ru_reference():
@@ -209,30 +213,23 @@ def make_email_address(local_part=None, domain=None):
     if not domain:
         domain = local_part
 
-    return common_utilities.concatenate_strings(common_utilities.concatenate_strings(local_part, '@'),
-                                                common_utilities.concatenate_strings(domain, '.com'))
+    return concatenate_strings(concatenate_strings(local_part, '@'), concatenate_strings(domain, '.com'))
 
 
 def format_survey_name(survey_name_in, social_survey, max_field_length):
+    timestamp = create_utc_timestamp()
+
     if social_survey:
-        prefix = common_utilities.concatenate_strings(SURVEY_NAME_SOCIAL_PREFIX, '', FIELD_SEPARATOR)
+        name = f"{SURVEY_NAME_SOCIAL_PREFIX}{FIELD_SEPARATOR}{survey_name_in}{FIELD_SEPARATOR}{timestamp}"
     else:
-        prefix = common_utilities.concatenate_strings(SURVEY_NAME_BUSINESS_PREFIX, '', FIELD_SEPARATOR)
+        name = f"{SURVEY_NAME_BUSINESS_PREFIX}{FIELD_SEPARATOR}{survey_name_in}{FIELD_SEPARATOR}{timestamp}"
 
-    # Append timestamp
-    survey_name_out = common_utilities.concatenate_strings(survey_name_in, common_utilities.create_utc_timestamp(),
-                                                           FIELD_SEPARATOR)
-
-    survey_name_out = common_utilities.compact_string(survey_name_out, max_field_length - len(prefix))
-
-    # return with prefix
-    return common_utilities.concatenate_strings(prefix, survey_name_out)
+    return compact_string(name, max_field_length)
 
 
 def create_survey_reference():
     ref = str(randint(SURVEY_REFERENCE_START, SURVEY_REFERENCE_END))
-
-    return common_utilities.concatenate_strings(SURVEY_REFERENCE_PREFIX, ref)
+    return f"{SURVEY_REFERENCE_PREFIX}{ref}"
 
 
 def create_phone_number():

--- a/run_in_parallel.py
+++ b/run_in_parallel.py
@@ -42,12 +42,7 @@ DELIMITER = '_BEHAVE_PARALLEL_BDD_'
 
 
 def is_valid_parallel_environment():
-    if os.getenv('IGNORE_SEQUENTIAL_DATA_SETUP') is None:
-        return False
-
-    is_ignore_sequential_data_setup = strtobool(os.getenv('IGNORE_SEQUENTIAL_DATA_SETUP'))
-
-    return is_ignore_sequential_data_setup
+    return strtobool(os.getenv('IGNORE_SEQUENTIAL_DATA_SETUP', 'False'))
 
 
 def parse_arguments():

--- a/run_in_sequence.py
+++ b/run_in_sequence.py
@@ -23,12 +23,8 @@ logger = wrap_logger(getLogger(__name__))
 
 
 def is_valid_sequential_environment():
-    if os.getenv('IGNORE_SEQUENTIAL_DATA_SETUP') is None:
-        return True
 
-    is_ignore_sequential_data_setup = strtobool(os.getenv('IGNORE_SEQUENTIAL_DATA_SETUP'))
-
-    return not is_ignore_sequential_data_setup
+    return not strtobool(os.getenv('IGNORE_SEQUENTIAL_DATA_SETUP', 'False'))
 
 
 def parse_arguments():

--- a/run_in_sequence.py
+++ b/run_in_sequence.py
@@ -23,7 +23,6 @@ logger = wrap_logger(getLogger(__name__))
 
 
 def is_valid_sequential_environment():
-
     return not strtobool(os.getenv('IGNORE_SEQUENTIAL_DATA_SETUP', 'False'))
 
 


### PR DESCRIPTION
# Motivation and Context
To spread the knowledge about parallel tests , modify survey chosen because of its relative independence

# What has changed
Modified test to use data created during fixture execution. Minor import clean up, minor code tweaks in is_valid_parallel_environment and is_valid_sequential_environment. 
Modified Create survey to be parallelizable. Added support for matching to context object attributes in feature then strings. E.g "Then they get an error message of 'Survey with ID {survey_ref} already exists" in create_survey.

REDUCED RANDOMNESS of survey reference from 6 integers to 5 since a 9 was mandated as first and 7 characters fails validation

# How to test?
Make sure acceptance tests pass, view with local ui to validate survey created during test 

# Links
 https://trello.com/c/kxHiqt1C