### PR TITLE
Feature tests for respondent on response status

### DIFF
--- a/acceptance_tests/features/display_respondent_alongside_response_status.feature
+++ b/acceptance_tests/features/display_respondent_alongside_response_status.feature
@@ -1,4 +1,5 @@
 @standalone
+@business
 @fixture.setup.data.with.enrolled.respondent.user.and.internal.user.and.new.iac.and.collection.exercise.to.live
 Feature: Internal user can search for a respondent via email
   As an internal user

--- a/acceptance_tests/features/display_respondent_alongside_response_status.feature
+++ b/acceptance_tests/features/display_respondent_alongside_response_status.feature
@@ -1,0 +1,26 @@
+@standalone
+@wip
+Feature: Internal user can search for a respondent via email
+  As an internal user
+  I need to be able to search for a registered respondent via their email
+  So that I can easily find them when dealing with operational calls
+
+#
+#  Background: internal user is already signed in
+#    Given the respondent is signed into their account
+
+  @fixture.setup.data.enrolled.respondent
+  @us211_01
+  Scenario: Respondent field must be present on each Survey displayed on Reporting units for any given Reference
+    Given an external user is enrolled onto a given survey
+    And has not initiated any changes to the "Not started" status
+    When an internal user navigates to Reporting units for that Reference
+    Then no Respondent name should be displayed in the Respondent field
+#
+#  @fixture.setup.data.enrolled.respondent
+#  Scenario: Respondent field must be updated once an external user has completed a survey online
+#    Given an external user is enrolled onto a given survey
+#    And the status is set to Completed
+#    When an internal user navigates to Reporting Units for that reference
+#    Then the Respondent details must be displayed in the Respondent field
+

--- a/acceptance_tests/features/display_respondent_alongside_response_status.feature
+++ b/acceptance_tests/features/display_respondent_alongside_response_status.feature
@@ -5,22 +5,39 @@ Feature: Internal user can search for a respondent via email
   I need to be able to search for a registered respondent via their email
   So that I can easily find them when dealing with operational calls
 
-#
-#  Background: internal user is already signed in
-#    Given the respondent is signed into their account
 
-  @fixture.setup.data.enrolled.respondent
+  @fixture.setup.data.with.enrolled.respondent.user.and.internal.user.and.new.iac.and.collection.exercise.to.live
   @us211_01
   Scenario: Respondent field must be present on each Survey displayed on Reporting units for any given Reference
     Given an external user is enrolled onto a given survey
     And has not initiated any changes to the "Not started" status
     When an internal user navigates to Reporting units for that Reference
     Then no Respondent name should be displayed in the Respondent field
-#
-#  @fixture.setup.data.enrolled.respondent
-#  Scenario: Respondent field must be updated once an external user has completed a survey online
-#    Given an external user is enrolled onto a given survey
-#    And the status is set to Completed
-#    When an internal user navigates to Reporting Units for that reference
-#    Then the Respondent details must be displayed in the Respondent field
 
+  @fixture.setup.data.with.enrolled.respondent.user.and.internal.user.and.new.iac.and.collection.exercise.to.live
+  Scenario: Respondent field must be updated once an external user has completed a survey online
+    Given  a user has completed a survey online
+    And the status is set to Completed
+    When an internal user navigates to Reporting Units for that reference
+    Then the Respondent details must be displayed in the Respondent field
+
+  @fixture.setup.data.with.enrolled.respondent.user.and.internal.user.and.new.iac.and.collection.exercise.to.live
+    Scenario: Respondent field must be updated once an external user has completed a survey online
+      Given a user has partially completed a survey (In progress)
+      And  the status is set to "In progress"
+      When an internal user navigates to Reporting Units for that reference
+      Then no Respondent name should be displayed in the Respondent field
+
+  @fixture.setup.data.with.enrolled.respondent.user.and.internal.user.and.new.iac.and.collection.exercise.to.live
+    Scenario: Respondent field must be updated once an external user has completed a survey online
+      Given a user has completed a survey via the telephone
+      And the status is set to "Completed by phone"
+      When an internal user navigates to Reporting Units for that reference
+      Then no Respondent name should be displayed in the Respondent field
+
+  @fixture.setup.data.with.enrolled.respondent.user.and.internal.user.and.new.iac.and.collection.exercise.to.live
+    Scenario: Respondent field must be updated once an external user has completed a survey online
+      Given an internal user has set a given survey to "No longer required" for a given respondent
+      And the status is set to "No longer required"
+      When an internal user navigates to Reporting Units for the no longer required reference
+      Then no longer required should be displayed in the survey collection exercise

--- a/acceptance_tests/features/display_respondent_alongside_response_status.feature
+++ b/acceptance_tests/features/display_respondent_alongside_response_status.feature
@@ -1,11 +1,11 @@
 @standalone
+@fixture.setup.data.with.enrolled.respondent.user.and.internal.user.and.new.iac.and.collection.exercise.to.live
 Feature: Internal user can search for a respondent via email
   As an internal user
   I need to be able to search for a registered respondent via their email
   So that I can easily find them when dealing with operational calls
 
 
-  @fixture.setup.data.with.enrolled.respondent.user.and.internal.user.and.new.iac.and.collection.exercise.to.live
   @us211_01
   Scenario: Respondent field must be present on each Survey displayed on Reporting units for any given Reference
     Given an external user is enrolled onto a given survey
@@ -13,30 +13,26 @@ Feature: Internal user can search for a respondent via email
     When an internal user navigates to Reporting units for that Reference
     Then no Respondent name should be displayed in the Respondent field
 
-  @fixture.setup.data.with.enrolled.respondent.user.and.internal.user.and.new.iac.and.collection.exercise.to.live
   Scenario: Respondent field must be updated once an external user has completed a survey online
     Given  a user has completed a survey online
     And the status is set to Completed
     When an internal user navigates to Reporting Units for that reference
     Then the Respondent details must be displayed in the Respondent field
 
-  @fixture.setup.data.with.enrolled.respondent.user.and.internal.user.and.new.iac.and.collection.exercise.to.live
-    Scenario: Respondent field must be updated once an external user has completed a survey online
-      Given a user has partially completed a survey (In progress)
-      And  the status is set to "In progress"
-      When an internal user navigates to Reporting Units for that reference
-      Then no Respondent name should be displayed in the Respondent field
+  Scenario: Respondent field must be updated once an external user has completed a survey online
+    Given a user has partially completed a survey (In progress)
+    And  the status is set to In Progress
+    When an internal user navigates to Reporting Units for that reference
+    Then no Respondent name should be displayed in the Respondent field
 
-  @fixture.setup.data.with.enrolled.respondent.user.and.internal.user.and.new.iac.and.collection.exercise.to.live
-    Scenario: Respondent field must be updated once an external user has completed a survey online
-      Given a user has completed a survey via the telephone
-      And the status is set to "Completed by phone"
-      When an internal user navigates to Reporting Units for that reference
-      Then no Respondent name should be displayed in the Respondent field
+  Scenario: Respondent field must be updated once an external user has completed a survey online
+    Given a user has completed a survey via the telephone
+    And the status is set to "Completed by phone"
+    When an internal user navigates to Reporting Units for that reference
+    Then no Respondent name should be displayed in the Respondent field
 
-  @fixture.setup.data.with.enrolled.respondent.user.and.internal.user.and.new.iac.and.collection.exercise.to.live
-    Scenario: Respondent field must be updated once an external user has completed a survey online
-      Given an internal user has set a given survey to "No longer required" for a given respondent
-      And the status is set to "No longer required"
-      When an internal user navigates to Reporting Units for the no longer required reference
-      Then no longer required should be displayed in the survey collection exercise
+  Scenario: Respondent field must be updated once an external user has completed a survey online
+    Given an internal user has set a given survey to "No longer required" for a given respondent
+    And the status is set to "No longer required"
+    When an internal user navigates to Reporting Units for the no longer required reference
+    Then no longer required should be displayed in the survey collection exercise

--- a/acceptance_tests/features/display_respondent_alongside_response_status.feature
+++ b/acceptance_tests/features/display_respondent_alongside_response_status.feature
@@ -20,19 +20,19 @@ Feature: Internal user can search for a respondent via email
     When an internal user navigates to Reporting Units for that reference
     Then the Respondent details must be displayed in the Respondent field
 
-  Scenario: Respondent field must be updated once an external user has completed a survey online
+  Scenario: Respondent field must not be updated once an external user has partially completed a survey online
     Given a user has partially completed a survey (In progress)
     And  the status is set to In Progress
     When an internal user navigates to Reporting Units for that reference
     Then no Respondent name should be displayed in the Respondent field
 
-  Scenario: Respondent field must be updated once an external user has completed a survey online
+  Scenario: Respondent field must not be updated once an external user has completed a survey via phone
     Given a user has completed a survey via the telephone
     And the status is set to "Completed by phone"
     When an internal user navigates to Reporting Units for that reference
     Then no Respondent name should be displayed in the Respondent field
 
-  Scenario: Respondent field must be updated once an external user has completed a survey online
+  Scenario: Respondent field must not be updated once an external user is no longer required to complete a survey
     Given an internal user has set a given survey to "No longer required" for a given respondent
     And the status is set to "No longer required"
     When an internal user navigates to Reporting Units for the no longer required reference

--- a/acceptance_tests/features/display_respondent_alongside_response_status.feature
+++ b/acceptance_tests/features/display_respondent_alongside_response_status.feature
@@ -1,5 +1,4 @@
 @standalone
-@wip
 Feature: Internal user can search for a respondent via email
   As an internal user
   I need to be able to search for a registered respondent via their email

--- a/acceptance_tests/features/pages/collection_exercise_details.py
+++ b/acceptance_tests/features/pages/collection_exercise_details.py
@@ -85,6 +85,10 @@ def load_collection_instrument(test_file):
     browser.find_by_id('btn-load-ci').click()
 
 
+def upload_collection_instrument(test_file):
+    browser.driver.find_element_by_id('selected-file').send_keys(abspath(test_file))
+
+
 def select_wrong_file_type(test_file):
     browser.driver.find_element_by_id('ciFile').send_keys(abspath(test_file))
 

--- a/acceptance_tests/features/send_message_from_todo_list.feature
+++ b/acceptance_tests/features/send_message_from_todo_list.feature
@@ -2,7 +2,6 @@
 @standalone
 @secure_messaging
 @fixture.setup.data.with.enrolled.respondent.user.and.internal.user.and.new.iac.and.collection.exercise.to.live
-@wip
 Feature: Send message from todo list
   As a Respondent
   I need to be able to send a secure message in relation to an RU and a survey in my todo list

--- a/acceptance_tests/features/steps/display_respondent_alongside_response_status.py
+++ b/acceptance_tests/features/steps/display_respondent_alongside_response_status.py
@@ -39,18 +39,17 @@ def user_completes_survey_by_telephone(context):
     change_response_status.update_response_status(mapped_status)
 
 
-@given('the status is set to "Completed by phone"')
-def survey_is_set_to_completed_by_telephone(context):
+@given('the status is set to "{status}"')
+def survey_set_to_longer_required(context, status):
     signed_in_respondent(context)
     go_to_history_tab()
-    assert browser.find_by_text('Completed by phone')
+    assert browser.find_by_text(status)
 
 
-@given('the status is set to "No longer required"')
-def survey_set_to_longer_required(context):
-    signed_in_respondent(context)
-    go_to_history_tab()
-    assert browser.find_by_text('No longer required')
+@given('the status is set to In Progress')
+def survey_set_to_in_progress(_):
+    surveys_todo.go_to()
+    assert browser.find_by_text('Downloaded')
 
 
 @given('an internal user has set a given survey to "No longer required" for a given respondent')
@@ -69,12 +68,6 @@ def respondent_partially_completes_survey(context):
     browser.click_link_by_id('access_survey_button_1')
     browser.click_link_by_id('download_survey_button')
     time.sleep(5)
-
-
-@given('the status is set to "In progress"')
-def survey_set_to_in_progress(_):
-    surveys_todo.go_to()
-    assert browser.find_by_text('Downloaded')
 
 
 @given('has not initiated any changes to the "Not started" status')

--- a/acceptance_tests/features/steps/display_respondent_alongside_response_status.py
+++ b/acceptance_tests/features/steps/display_respondent_alongside_response_status.py
@@ -1,7 +1,7 @@
 import logging
 
-import time
 from behave import given, when, then
+from selenium.webdriver.support.wait import WebDriverWait
 from structlog import wrap_logger
 
 from acceptance_tests import browser
@@ -49,7 +49,15 @@ def survey_set_to_longer_required(context, status):
 @given('the status is set to In Progress')
 def survey_set_to_in_progress(_):
     surveys_todo.go_to()
-    assert browser.find_by_text('Downloaded')
+    status = WebDriverWait(browser, timeout=60, poll_frequency=10).until(wait_for_text_on_screen)
+    assert status[0].text == 'Downloaded'
+
+
+def wait_for_text_on_screen(browser):
+    browser.reload()
+    elem = browser.find_by_text('Downloaded')
+    if elem[0].text == 'Downloaded':
+        return elem
 
 
 @given('an internal user has set a given survey to "No longer required" for a given respondent')
@@ -67,7 +75,6 @@ def respondent_partially_completes_survey(context):
     signed_in_respondent(context)
     browser.click_link_by_id('access_survey_button_1')
     browser.click_link_by_id('download_survey_button')
-    time.sleep(5)
 
 
 @given('has not initiated any changes to the "Not started" status')

--- a/acceptance_tests/features/steps/display_respondent_alongside_response_status.py
+++ b/acceptance_tests/features/steps/display_respondent_alongside_response_status.py
@@ -1,46 +1,92 @@
 import logging
-from pprint import pprint
 
 import time
 from behave import given, when, then
 from structlog import wrap_logger
 
 from acceptance_tests import browser
-from acceptance_tests.features.pages import reporting_unit, collection_exercise_details, sign_in_respondent
-from acceptance_tests.features.steps.authentication import signed_in_respondent, signed_in_internal
+from acceptance_tests.features.pages import reporting_unit, collection_exercise_details, \
+    change_response_status, surveys_todo
+from acceptance_tests.features.pages.surveys_history import go_to_history_tab
+from acceptance_tests.features.steps.authentication import signed_in_internal, signed_in_respondent
 from acceptance_tests.features.steps.change_response_status import go_to_reporting_unit_page
-from config import Config
+from controllers.collection_exercise_controller import map_ce_status
 
 logger = wrap_logger(logging.getLogger(__name__))
 
 
-@given('an external user is enrolled onto a given survey')
+@given('a user has completed a survey online')
 def enrolling_onto_survey(context):
-    enrolled_respondent_sign_in(context)
+    signed_in_respondent(context)
     browser.click_link_by_id('access_survey_button_1')
     collection_exercise_details.upload_collection_instrument(
         test_file='resources/collection_instrument_files/064_201803_0001.xlsx')
     browser.find_by_id('upload_survey_button').click()
 
 
-def enrolled_respondent_sign_in(context):
-    sign_in_respondent.go_to()
-    # Only attempt to sign in if not already signed in otherwise implicitly redirected to homepage
-    if '/sign-in' in browser.url:
-        browser.driver.find_element_by_id('username').send_keys(context.user_name)
-        browser.driver.find_element_by_id('inputPassword').send_keys(Config.RESPONDENT_PASSWORD)
-        time.sleep(40)
-        browser.find_by_id('sign_in_button').click()
+@given('an external user is enrolled onto a given survey')
+def enrolled_respondent_but_not_completed(context):
+    signed_in_respondent(context)
+
+
+@given('a user has completed a survey via the telephone')
+def user_completes_survey_by_telephone(context):
+    signed_in_internal(())
+    go_to_reporting_unit_page(context)
+    reporting_unit.click_data_panel(context.short_name)
+    reporting_unit.click_change_response_status_link(survey=context.short_name, period=context.period)
+    mapped_status = map_ce_status('Completed by phone')
+    change_response_status.update_response_status(mapped_status)
+
+
+@given('the status is set to "Completed by phone"')
+def survey_is_set_to_completed_by_telephone(context):
+    signed_in_respondent(context)
+    go_to_history_tab()
+    assert browser.find_by_text('Completed by phone')
+
+
+@given('the status is set to "No longer required"')
+def survey_set_to_longer_required(context):
+    signed_in_respondent(context)
+    go_to_history_tab()
+    assert browser.find_by_text('No longer required')
+
+
+@given('an internal user has set a given survey to "No longer required" for a given respondent')
+def survey_is_set_to_no_longer_required(context):
+    signed_in_internal(())
+    go_to_reporting_unit_page(context)
+    reporting_unit.click_data_panel(context.short_name)
+    reporting_unit.click_change_response_status_link(survey=context.short_name, period=context.period)
+    mapped_status = map_ce_status('No longer required')
+    change_response_status.update_response_status(mapped_status)
+
+
+@given('a user has partially completed a survey (In progress)')
+def respondent_partially_completes_survey(context):
+    signed_in_respondent(context)
+    browser.click_link_by_id('access_survey_button_1')
+    browser.click_link_by_id('download_survey_button')
+    time.sleep(5)
+
+
+@given('the status is set to "In progress"')
+def survey_set_to_in_progress(_):
+    surveys_todo.go_to()
+    assert browser.find_by_text('Downloaded')
 
 
 @given('has not initiated any changes to the "Not started" status')
 def no_changes_have_been_made_to_collex(_):
-    pass
+    assert browser.find_by_text('Not started')
 
 
 @given('the status is set to Completed')
 def status_set_to_completed(_):
-    pass
+    surveys_todo.go_to()
+    go_to_history_tab()
+    assert browser.find_by_text('Complete')
 
 
 @when('an internal user navigates to Reporting units for that Reference')
@@ -51,6 +97,26 @@ def navigating_to_reporting_units(context):
     reporting_unit.click_change_response_status_link(survey=context.short_name, period=context.period)
 
 
+@when('an internal user navigates to Reporting Units for the no longer required reference')
+def collex_set_to_no_longer_required(context):
+    signed_in_internal(())
+    go_to_reporting_unit_page(context)
+    reporting_unit.click_data_panel(context.short_name)
+
+
+@then('no longer required should be displayed in the survey collection exercise')
+def no_longer_required_set_for_collex(_):
+    assert 'No longer required' in browser.html
+
+
 @then('no Respondent name should be displayed in the Respondent field')
-def respondent_name_is_not_displayed(context):
+def respondent_name_is_not_displayed(_):
     assert 'Respondent:' in browser.html
+    assert browser.find_by_id('completed-respondent')[0].value is ''
+
+
+@then('the Respondent details must be displayed in the Respondent field')
+def respondent_name_is_displayed(_):
+    assert 'Respondent:' in browser.html
+    respondent = browser.find_by_id('completed-respondent')[0].value
+    assert respondent == 'first_name last_name'

--- a/acceptance_tests/features/steps/display_respondent_alongside_response_status.py
+++ b/acceptance_tests/features/steps/display_respondent_alongside_response_status.py
@@ -1,0 +1,56 @@
+import logging
+from pprint import pprint
+
+import time
+from behave import given, when, then
+from structlog import wrap_logger
+
+from acceptance_tests import browser
+from acceptance_tests.features.pages import reporting_unit, collection_exercise_details, sign_in_respondent
+from acceptance_tests.features.steps.authentication import signed_in_respondent, signed_in_internal
+from acceptance_tests.features.steps.change_response_status import go_to_reporting_unit_page
+from config import Config
+
+logger = wrap_logger(logging.getLogger(__name__))
+
+
+@given('an external user is enrolled onto a given survey')
+def enrolling_onto_survey(context):
+    enrolled_respondent_sign_in(context)
+    browser.click_link_by_id('access_survey_button_1')
+    collection_exercise_details.upload_collection_instrument(
+        test_file='resources/collection_instrument_files/064_201803_0001.xlsx')
+    browser.find_by_id('upload_survey_button').click()
+
+
+def enrolled_respondent_sign_in(context):
+    sign_in_respondent.go_to()
+    # Only attempt to sign in if not already signed in otherwise implicitly redirected to homepage
+    if '/sign-in' in browser.url:
+        browser.driver.find_element_by_id('username').send_keys(context.user_name)
+        browser.driver.find_element_by_id('inputPassword').send_keys(Config.RESPONDENT_PASSWORD)
+        time.sleep(40)
+        browser.find_by_id('sign_in_button').click()
+
+
+@given('has not initiated any changes to the "Not started" status')
+def no_changes_have_been_made_to_collex(_):
+    pass
+
+
+@given('the status is set to Completed')
+def status_set_to_completed(_):
+    pass
+
+
+@when('an internal user navigates to Reporting units for that Reference')
+def navigating_to_reporting_units(context):
+    signed_in_internal(())
+    go_to_reporting_unit_page(context)
+    reporting_unit.click_data_panel(context.short_name)
+    reporting_unit.click_change_response_status_link(survey=context.short_name, period=context.period)
+
+
+@then('no Respondent name should be displayed in the Respondent field')
+def respondent_name_is_not_displayed(context):
+    assert 'Respondent:' in browser.html


### PR DESCRIPTION
# Motivation and Context
Feature tests for adding respondent name to the response status page in R-ops.

# What has changed
- Added feature file `display_respondent_alongside_response_status`

# How to test?
- Run with the [Response-ops PR](https://github.com/ONSdigital/response-operations-ui/pull/267) and run the acceptance tests. All should pass
# Links
[Trello](https://trello.com/c/1rcfmtok)
