### PR TITLE
Use thread pool for parallel execution, stop gracefully on test failure

### DIFF
--- a/run_in_parallel.py
+++ b/run_in_parallel.py
@@ -71,13 +71,8 @@ def is_process_running(process):
     return process is not None and process.is_alive()
 
 
-def _run_scenario(failure_queue: Queue, scenario, timeout, command_line_args):
-    """
-    Runs features/scenarios
-    :return: Feature/scenario and status
-    """
-
-    feature, scenario = scenario.split(DELIMITER)
+def _run_scenario(failure_queue: Queue, feature_scenario: str, timeout, command_line_args):
+    feature, scenario = feature_scenario.split(DELIMITER)
     logger.info(f'Starting Feature: [{feature}], Scenario [{scenario}]')
 
     execution_code = {0: 'OK', 1: 'FAILED', 2: 'TIMEOUT', 3: 'UNEXPECTED_ERROR'}
@@ -138,7 +133,7 @@ def run_all_scenarios(scenarios_to_run, max_threads, timeout, command_line_args,
     return total_scenarios_run, failure_queue
 
 
-def get_thread_pool_size(max_threads, number_of_scenarios_to_run):
+def get_thread_pool_size(max_threads: int, number_of_scenarios_to_run: int) -> int:
     return max_threads if number_of_scenarios_to_run > max_threads else number_of_scenarios_to_run
 
 

--- a/run_in_parallel.py
+++ b/run_in_parallel.py
@@ -71,7 +71,7 @@ def is_process_running(process):
     return process is not None and process.is_alive()
 
 
-def _run_scenario(scenario, failure_queue: Queue, timeout, command_line_args):
+def _run_scenario(failure_queue: Queue, scenario, timeout, command_line_args):
     """
     Runs features/scenarios
     :return: Feature/scenario and status
@@ -117,7 +117,7 @@ def run_all_scenarios(scenarios_to_run, max_threads, timeout, command_line_args,
     failure_queue = Queue()
 
     with ThreadPoolExecutor(max_workers=thread_pool_size) as executor:
-        scenario_futures = [executor.submit(_run_scenario, scenario, failure_queue, timeout, command_line_args)
+        scenario_futures = [executor.submit(_run_scenario, failure_queue, scenario, timeout, command_line_args)
                             for scenario in scenarios_to_run]
 
         aborting = False
@@ -139,11 +139,7 @@ def run_all_scenarios(scenarios_to_run, max_threads, timeout, command_line_args,
 
 
 def get_thread_pool_size(max_threads, number_of_scenarios_to_run):
-    if number_of_scenarios_to_run < max_threads:
-        thread_pool_size = number_of_scenarios_to_run
-    else:
-        thread_pool_size = max_threads
-    return thread_pool_size
+    return max_threads if number_of_scenarios_to_run > max_threads else number_of_scenarios_to_run
 
 
 def find_matching_features_and_scenarios(tags, acceptance_features_directory):

--- a/run_in_parallel.py
+++ b/run_in_parallel.py
@@ -12,12 +12,13 @@ import logging
 import os
 import sys
 import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime
 from distutils.util import strtobool
-from multiprocessing import Process, Queue
-from subprocess import Popen, PIPE, check_output, CalledProcessError, TimeoutExpired
+from multiprocessing import Queue
+from subprocess import CalledProcessError, PIPE, Popen, TimeoutExpired, check_output
 
-from common.common_utilities import create_behave_tags, kill_all_processes, get_child_processes
+from common.common_utilities import create_behave_tags, get_child_processes, kill_all_processes
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -55,6 +56,8 @@ def parse_arguments():
     parser.add_argument('--test_tags', '-t', help='specify behave tags to run', default=DEFAULT_TAGS)
     parser.add_argument('--timeout', '-tout', type=int,
                         help='Maximum seconds to execute each scenario. Default = 300', default=300)
+    parser.add_argument('--parallel-stop', '-s', help='Gracefully stop parallel test execution on a failure',
+                        action='store_true')
 
     args = parser.parse_args()
 
@@ -68,16 +71,16 @@ def is_process_running(process):
     return process is not None and process.is_alive()
 
 
-def _run_scenario(q, feature_scenario, timeout, command_line_args):
+def _run_scenario(scenario, failure_queue: Queue, timeout, command_line_args):
     """
     Runs features/scenarios
-    :param feature_scenario: Feature/scenario that should be run
-    :type feature_scenario: str
     :return: Feature/scenario and status
     """
 
+    feature, scenario = scenario.split(DELIMITER)
+    logger.info(f'Running feature: {feature}, scenario: {scenario}')
+
     execution_code = {0: 'OK', 1: 'FAILED', 2: 'TIMEOUT', 3: 'UNEXPECTED_ERROR'}
-    feature, scenario = feature_scenario.split(DELIMITER)
 
     cmd = f'behave {command_line_args} --format progress2 {feature} --name \"{scenario}\"'
 
@@ -98,7 +101,7 @@ def _run_scenario(q, feature_scenario, timeout, command_line_args):
     logger.info(f"{feature:50}: {scenario} --> {status}")
 
     if status == 'FAILED':
-        q.put(f'FAILED - Feature: [{feature}], Scenario [{scenario}]"')
+        failure_queue.put(f'FAILED - Feature: [{feature}], Scenario [{scenario}]"')
         logger.error(out_bytes.decode())
 
     # To give time for postgres connections to close before starting the next Scenario
@@ -107,59 +110,41 @@ def _run_scenario(q, feature_scenario, timeout, command_line_args):
     return feature, scenario, status
 
 
-def run_all_scenarios(scenarios_to_run, process_count, timeout, command_line_args):
-    total_scenarios_to_run = len(scenarios_to_run)
+def run_all_scenarios(scenarios_to_run, max_threads, timeout, command_line_args, stop_on_failure):
+    total_scenarios_run = 0
 
-    # Set number of threads needed
-    if total_scenarios_to_run < process_count:
-        process_pool_size = total_scenarios_to_run
+    thread_pool_size = get_thread_pool_size(max_threads, len(scenarios_to_run))
+
+    failure_queue = Queue()
+
+    with ThreadPoolExecutor(max_workers=thread_pool_size) as executor:
+        future_to_scenario = {executor.submit(_run_scenario, scenario, failure_queue, timeout, command_line_args)
+                              : scenario for scenario in scenarios_to_run}
+
+        aborting = False
+        for future in as_completed(future_to_scenario):
+            if not future.cancelled():
+                if not aborting and not failure_queue.empty() and stop_on_failure:
+                    aborting = True
+                    logger.info('Test failure, aborting')
+                    for future_to_cancel in future_to_scenario:
+                        future_to_cancel.cancel()
+                try:
+                    future.result()
+                except Exception:
+                    logger.exception('System Error')
+                    failure_queue.put('System Error')
+                total_scenarios_run += 1
+
+    return total_scenarios_run, failure_queue
+
+
+def get_thread_pool_size(max_threads, number_of_scenarios_to_run):
+    if number_of_scenarios_to_run < max_threads:
+        thread_pool_size = number_of_scenarios_to_run
     else:
-        process_pool_size = process_count
-
-    process_pool = [None] * process_pool_size
-    scenario_index = 0
-    processes_running = True
-    failure_queue = Queue(maxsize=0)
-
-    # Run every scenario
-    while processes_running:
-
-        # Find a 'Free' Thread slot
-        for process_index in range(process_pool_size):
-
-            # Found one
-            if not is_process_running(process_pool[process_index]):
-                feature, scenario = scenarios_to_run[scenario_index].split(DELIMITER)
-
-                logger.info(
-                    f"Processing Feature [{scenario_index}] : [{feature}], Scenario [{scenario}] in [{process_index}]")
-                process_pool[process_index] = Process(target=_run_scenario, args=(failure_queue,
-                                                                                  scenarios_to_run[scenario_index],
-                                                                                  timeout, command_line_args))
-                process_pool[process_index].start()
-
-                scenario_index += 1
-
-                if scenario_index == total_scenarios_to_run:
-                    break
-
-        # If last Scenario has started, wait for it to finish
-        if scenario_index == total_scenarios_to_run:
-
-            while processes_running:
-
-                # Assume all finished
-                processes_running = False
-
-                for process in process_pool:
-                    if is_process_running(process):
-                        processes_running = True
-                        time.sleep(3)
-                        break
-        else:
-            time.sleep(3)
-
-    return total_scenarios_to_run, failure_queue
+        thread_pool_size = max_threads
+    return thread_pool_size
 
 
 def find_matching_features_and_scenarios(tags, acceptance_features_directory):
@@ -250,7 +235,7 @@ def main():
 
     start_time = datetime.now()
     total_scenarios_run, failure_queue = run_all_scenarios(scenarios_to_run, args.processes, args.timeout,
-                                                           args.command_line_args)
+                                                           args.command_line_args, args.parallel_stop)
 
     exit_code = print_summary(start_time, datetime.now(), total_scenarios_run, failure_queue)
 

--- a/run_in_parallel.py
+++ b/run_in_parallel.py
@@ -78,7 +78,7 @@ def _run_scenario(failure_queue: Queue, scenario, timeout, command_line_args):
     """
 
     feature, scenario = scenario.split(DELIMITER)
-    logger.info(f'Running feature: {feature}, scenario: {scenario}')
+    logger.info(f'Starting Feature: [{feature}], Scenario [{scenario}]')
 
     execution_code = {0: 'OK', 1: 'FAILED', 2: 'TIMEOUT', 3: 'UNEXPECTED_ERROR'}
 


### PR DESCRIPTION
# Motivation and Context
Currently the `run_in_parallel.py` script uses processes to parallelise execution. This PR changes this to use a standard library thread execution pool. It also defaults to gracefully stopping on the first failure, with the option to turn this off. This will cancel all not started scenarios and allow any in progress to complete before exiting.

# What has changed
- Use thread execution pool for parallel test execution
- Stop parallel tests on first failure by default
- Add command line option to not stop on first failure
- Small refactor of parallel _run_scenario function

# How to test?
Run the tests locally, all the parallel tests should still pass and the execution time should not be worse than before the changes.
Introduce a forced test failure and check the tests stop (note they will finish executing any other tests in progress rather than shutting down immediately).

# Links
https://trello.com/c/o1SDodzq/380-acceptance-tests-terminate-parallel-execution-gracefully-on-failure
