### PR TITLE
Force hung statements to abort

### DIFF
--- a/controllers/database_controller.py
+++ b/controllers/database_controller.py
@@ -10,8 +10,9 @@ logger = wrap_logger(logging.getLogger(__name__))
 
 
 def execute_sql(sql_script_file_path=None, sql_string=None, database_uri=Config.DATABASE_URI):
+    print(f'Executing SQL script {sql_script_file_path}')
     logger.debug('Executing SQL script', sql_script_file_path=sql_script_file_path)
-    engine = create_engine(database_uri)
+    engine = create_engine(database_uri, connect_args={"options": "-c statement_timeout=120000"})
     connection = engine.connect()
     trans = connection.begin()
 


### PR DESCRIPTION
# Motivation and Context
Our CI pipeline is hanging indefinitely because SQL is being executed, which never completes. We should abort after a reasonable timeout, so that the pipeline goes wrong and we fix the problem.

# What has changed
Added log line. Added timeout of 2 minutes for a single SQL script to run, which should be plenty for the reset databases scripts.

# How to test?
Run the acceptance tests. When this runs in the pipeline, we should see build failures instead of hung builds.

# Links
Trello: https://trello.com/c/1kikLuEl/594-bug-force-ci-pipeline-to-abort-sql-db-cleardown-scripts-that-hang