### PR TITLE
Remaining secure message tests converted to standalone

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,11 @@ rasrm_acceptance_parallel_tests:
 	export IGNORE_SEQUENTIAL_DATA_SETUP=True; \
 	pipenv run python run_in_parallel.py --test_tags "${TEST_TAGS}"
 
+secure_messaging_acceptance_tests: TEST_TAGS = @secure_messaging
+secure_messaging_acceptance_tests:
+	export IGNORE_SEQUENTIAL_DATA_SETUP=True; \
+	pipenv run python run_in_parallel.py --test_tags "${TEST_TAGS}"
+
 
 # Run sequentially with behave targets
 #todo eventually these will be converted and moved above/deleted
@@ -81,11 +86,6 @@ social_acceptance_tests: TEST_TARGET = acceptance_tests/features
 social_acceptance_tests: TEST_TAGS = @social
 social_acceptance_tests: setup
 social_acceptance_tests:
-	pipenv run behave --stop --format ${BEHAVE_FORMAT} --tags ${TEST_TAGS} ${TEST_TARGET}
-
-secure_messaging_acceptance_tests: TEST_TARGET = acceptance_tests/features
-secure_messaging_acceptance_tests: TEST_TAGS = @secure_messaging
-secure_messaging_acceptance_tests:
 	pipenv run behave --stop --format ${BEHAVE_FORMAT} --tags ${TEST_TAGS} ${TEST_TARGET}
 
 run_tests:

--- a/acceptance_tests/features/create_message_internal.feature
+++ b/acceptance_tests/features/create_message_internal.feature
@@ -13,8 +13,8 @@ Feature: Internal user to send message
 
   @sm101_s01
   Scenario: 'To' field will be pre-populated with respondent name (up to 100 characters)
-    When they choose to send them a secure message and navigated to the 'send message' page
-    Then the 'To' field is populated with the respondent's name
+    When they choose to send them a secure message and navigated to the send message page
+    Then the To field is populated with the respondent's name
 
   @sm101_s02
   Scenario: User is able to enter free text in the subject field up to and including 96 characters

--- a/acceptance_tests/features/create_message_internal.feature
+++ b/acceptance_tests/features/create_message_internal.feature
@@ -1,4 +1,7 @@
+@business
+@standalone
 @secure_messaging
+@fixture.setup.data.with.enrolled.respondent.user.and.internal.user.and.new.iac.and.collection.exercise.to.live
 Feature: Internal user to send message
   As an internal ONS user
   I need to be able to send a secure message

--- a/acceptance_tests/features/edit_respondent_details.feature
+++ b/acceptance_tests/features/edit_respondent_details.feature
@@ -1,3 +1,4 @@
+@business
 @standalone
 Feature: As an internal user
   I need to be able to change a respondents details

--- a/acceptance_tests/features/pages/create_message_internal.py
+++ b/acceptance_tests/features/pages/create_message_internal.py
@@ -25,9 +25,7 @@ def get_ru_details_attributes():
 
 def found_respondent_details(context):
     return {'ru_ref': context.short_name,
-            'to': 'first_name last_name',
-            'to_uuid': context.respondent_user_name,
-            'to_ru_id': context.party_id}
+            'to': 'first_name last_name'}
 
 
 def get_subject_and_body():

--- a/acceptance_tests/features/pages/create_message_internal.py
+++ b/acceptance_tests/features/pages/create_message_internal.py
@@ -1,14 +1,13 @@
 from acceptance_tests import browser
 from acceptance_tests.features.pages.reporting_unit import click_data_panel
-from common.respondent_details import RESPONDENT_DETAILS
 from config import Config
 
 
-def go_to():
+def go_to(context):
     browser.visit(f'{Config.RESPONSE_OPERATIONS_UI}'
                   "/reporting-units/"
-                  f"{RESPONDENT_DETAILS.get_ru_ref()}")
-    click_data_panel('Bricks')
+                  f"{context.short_name}")
+    click_data_panel(context.short_name)
     browser.find_by_id("create-message-button-1").click()
     assert "messages/create-message" in browser.url
 
@@ -24,11 +23,11 @@ def get_ru_details_attributes():
     return ru_details_table_attributes
 
 
-def found_respondent_details():
-    return {'ru_ref': RESPONDENT_DETAILS.get_ru_ref(),
+def found_respondent_details(context):
+    return {'ru_ref': context.short_name,
             'to': 'first_name last_name',
-            'to_uuid': RESPONDENT_DETAILS.get_respondent_id(),
-            'to_ru_id': RESPONDENT_DETAILS.get_ru_id()}
+            'to_uuid': context.respondent_user_name,
+            'to_ru_id': context.party_id}
 
 
 def get_subject_and_body():

--- a/acceptance_tests/features/send_message_from_todo_list.feature
+++ b/acceptance_tests/features/send_message_from_todo_list.feature
@@ -1,4 +1,8 @@
+@business
+@standalone
 @secure_messaging
+@fixture.setup.data.with.enrolled.respondent.user.and.internal.user.and.new.iac.and.collection.exercise.to.live
+@wip
 Feature: Send message from todo list
   As a Respondent
   I need to be able to send a secure message in relation to an RU and a survey in my todo list
@@ -20,9 +24,9 @@ Feature: Send message from todo list
 
   @sm137-03
   Scenario: The message is to be sent to a selected survey team mailbox
-    Given the respondent is sending a message in relation to bricks
+    Given the respondent is sending a message
     When the respondent enters a valid message
-    Then the message will be sent to the internal Bricks mailbox
+    Then the message will be sent to the internal mailbox
 
   @sm137-04
   Scenario: Subject field can be max 96 characters long

--- a/acceptance_tests/features/steps/create_message_internal.py
+++ b/acceptance_tests/features/steps/create_message_internal.py
@@ -2,25 +2,28 @@ from behave import given, when, then
 
 from acceptance_tests import browser
 from acceptance_tests.features.pages import create_message_internal
+from common.collection_exercise_utilities import find_case_by_enrolment_code
 
 
 @given("The internal user has found the associated respondent")
-def user_has_found_respondent(_):
-    assert create_message_internal.RESPONDENT_DETAILS.get_respondent_id() is not None
-    assert create_message_internal.RESPONDENT_DETAILS.get_ru_id() is not None
-    assert create_message_internal.RESPONDENT_DETAILS.get_ru_ref() is not None
+def user_has_found_respondent(context):
+    context.party_id = find_case_by_enrolment_code(context.iac)['partyId']
+
+    assert context.respondent_user_name is not None
+    assert context.party_id is not None
+    assert context.short_name is not None
 
 
 @when("they choose to send them a secure message and navigated to the 'send message' page")
 @given("the user is on the send message page")
-def navigate_to_send_message(_):
-    create_message_internal.go_to()
+def navigate_to_send_message(context):
+    create_message_internal.go_to(context)
 
 
 @then("the \'To\' field is populated with the respondent's name")
-def check_to_field(_):
+def check_to_field(context):
     to_field = create_message_internal.get_ru_details_attributes().get('to')
-    assert str(to_field) == create_message_internal.found_respondent_details().get('to')
+    assert str(to_field) == create_message_internal.found_respondent_details(context).get('to')
 
 
 @when("they enter text in the subject of the message")
@@ -80,8 +83,8 @@ def user_cancels_sending_message(_):
 
 
 @then("they are navigated back to the page in which they navigated from")
-def user_is_navigated_back(_):
-    assert f"reporting-units/{create_message_internal.RESPONDENT_DETAILS.get_ru_ref()}" in browser.url
+def user_is_navigated_back(context):
+    assert f"reporting-units/{context.short_name}" in browser.url
 
 
 @then("they are navigated to the inbox of messages")

--- a/acceptance_tests/features/steps/create_message_internal.py
+++ b/acceptance_tests/features/steps/create_message_internal.py
@@ -14,13 +14,13 @@ def user_has_found_respondent(context):
     assert context.short_name is not None
 
 
-@when("they choose to send them a secure message and navigated to the 'send message' page")
+@when("they choose to send them a secure message and navigated to the send message page")
 @given("the user is on the send message page")
 def navigate_to_send_message(context):
     create_message_internal.go_to(context)
 
 
-@then("the \'To\' field is populated with the respondent's name")
+@then("the To field is populated with the respondent's name")
 def check_to_field(context):
     to_field = create_message_internal.get_ru_details_attributes().get('to')
     assert str(to_field) == create_message_internal.found_respondent_details(context).get('to')

--- a/acceptance_tests/features/steps/send_message_from_todo_list.py
+++ b/acceptance_tests/features/steps/send_message_from_todo_list.py
@@ -1,8 +1,8 @@
 from behave import given, when, then
 
+import acceptance_tests.features.pages.view_and_reply_conversation_external as page_helpers
 from acceptance_tests import browser
 from acceptance_tests.features.pages import surveys_todo, create_message_external
-import acceptance_tests.features.pages.view_and_reply_conversation_external as page_helpers
 
 
 @given('the respondent is on their todo list')
@@ -17,7 +17,7 @@ def able_to_send_message_for_survey_ru(_):
 
 
 @given('the respondent chooses to send a message to ONS')
-@given('the respondent is sending a message in relation to bricks')
+@given('the respondent is sending a message')
 @when('the respondent chooses to send a message for a specific RU and survey')
 def select_create_message(_):
     surveys_todo.go_to()
@@ -47,10 +47,10 @@ def enter_valid_message(_):
     create_message_external.enter_valid_body('345')
 
 
-@then('the message will be sent to the internal Bricks mailbox')
-def message_sent_to_bricks_workgroup(_):
+@then('the message will be sent to the internal mailbox')
+def message_sent_to_bricks_workgroup(context):
     current_url = browser.driver.current_url
-    assert 'survey=cb8accda-6118-4d3b-85a3-149e28960c54' in current_url
+    assert context.survey_id in current_url
 
 
 @when('the respondent enters more than 96 characters in the subject field')

--- a/common/string_utilities.py
+++ b/common/string_utilities.py
@@ -7,7 +7,7 @@ def substitute_context_values(context, raw_string):
     value from context. Will ignore spaces after '{' and before '}'
      """
     new_string = raw_string.replace('{context.', '{')
-    matches = re.findall('{[\sa-zA-Z0-9_]+}', raw_string)
+    matches = re.findall('{[ sa-zA-Z0-9_]+}', raw_string)
 
     for match_str in matches:
         context_attr = match_str.replace('{', '').replace('}', '').strip()


### PR DESCRIPTION
# Motivation and Context
Remaining secure message tests converted to standalone

# How to test?
make setup acceptance_tests
and then
make secure_messaging_acceptance_tests

# Links
[Trello](https://trello.com/c/T0p0Gilm/386-t386convert-remaining-secure-messaging-features-to-standalone)