### PR TITLE
Standalone access eq collection exercise feature

### DIFF
--- a/acceptance_tests/features/access_eq_collection_exercise.feature
+++ b/acceptance_tests/features/access_eq_collection_exercise.feature
@@ -1,3 +1,4 @@
+@standalone
 Feature: Respondent can access an eQ CE
   As a Respondent
   I need to be able to access an eQ CE
@@ -7,6 +8,7 @@ Feature: Respondent can access an eQ CE
     Given the respondent is signed into their account
 
   @us062-accessEqCE_s01
+  @fixture.setup.data.with.enrolled.respondent.user.and.eq.collection.exercise.live
   Scenario: Access eQ CE
     Given the respondent has a CE for an eQ available
     When the respondent accesses the eQ CE

--- a/acceptance_tests/features/access_eq_collection_exercise.feature
+++ b/acceptance_tests/features/access_eq_collection_exercise.feature
@@ -13,4 +13,4 @@ Feature: Respondent can access an eQ CE
   Scenario: Access eQ CE
     Given the respondent has a CE for an eQ available
     When the respondent accesses the eQ CE
-    Then the respondent lands on the correct eQ Homepage for the survey and CE and CI
+    Then the respondent is redirected to eQ with a token

--- a/acceptance_tests/features/access_eq_collection_exercise.feature
+++ b/acceptance_tests/features/access_eq_collection_exercise.feature
@@ -1,4 +1,5 @@
 @standalone
+@business
 Feature: Respondent can access an eQ CE
   As a Respondent
   I need to be able to access an eQ CE

--- a/acceptance_tests/features/environment.py
+++ b/acceptance_tests/features/environment.py
@@ -10,6 +10,7 @@ from acceptance_tests import browser
 from acceptance_tests.features.fixtures import setup_data_survey_with_internal_user, \
     setup_data_with_2_enrolled_respondent_users_and_internal_user, \
     setup_data_with_enrolled_respondent_user_and_collection_exercise_to_live, \
+    setup_data_with_enrolled_respondent_user_and_eq_collection_exercise_live, \
     setup_data_with_enrolled_respondent_user_and_internal_user, \
     setup_data_with_enrolled_respondent_user_and_internal_user_and_new_iac_and_collection_exercise_to_live, \
     setup_data_with_internal_user, setup_data_with_internal_user_and_collection_exercise_to_created_status, \
@@ -62,7 +63,9 @@ fixture_scenario_registry = {
     'fixture.setup.data.with.2.enrolled.respondent.users.and.internal.user':
         setup_data_with_2_enrolled_respondent_users_and_internal_user,
     'fixture.setup.data.with.enrolled.respondent.user.and.collection.exercise.to.live':
-        setup_data_with_enrolled_respondent_user_and_collection_exercise_to_live
+        setup_data_with_enrolled_respondent_user_and_collection_exercise_to_live,
+    'fixture.setup.data.with.enrolled.respondent.user.and.eq.collection.exercise.live':
+        setup_data_with_enrolled_respondent_user_and_eq_collection_exercise_live
 }
 
 

--- a/acceptance_tests/features/fixtures.py
+++ b/acceptance_tests/features/fixtures.py
@@ -172,6 +172,14 @@ def setup_data_with_2_enrolled_respondent_users_and_internal_user(context):
     context.used_email_address = create_respondent_email_address(second_ru_ref)
     create_respondent(context.used_email_address, new_iac, context.phone_number)
     create_respondent_user_login_account(context.used_email_address)
+    
+
+@fixture
+def setup_data_with_enrolled_respondent_user_and_eq_collection_exercise_live(context):
+    create_default_data(context, eq_ci=True)
+    collection_exercise_controller.wait_for_collection_exercise_state(context.survey_id, context.period,
+                                                                      expected_state=COLLECTION_EXERCISE_STATUS_LIVE)
+    create_enrolled_respondent_for_the_test_survey(context)
 
 
 def create_internal_user(context):
@@ -222,7 +230,7 @@ def create_data_for_collection_exercise():
     }
 
 
-def create_default_data(context):
+def create_default_data(context, eq_ci=False):
     logger.debug(
         f'Feature [{context.feature_name}], Scenario [{context.scenario_name}] creating default Survey & Exercise')
 
@@ -244,7 +252,7 @@ def create_default_data(context):
                                                              survey_type)
     else:
         context.iac = create_test_business_collection_exercise(survey_id, period, short_name, scenario_name,
-                                                               survey_type)
+                                                               survey_type, eq_ci=eq_ci)
 
     # Save values for later
     context.period = period
@@ -274,7 +282,8 @@ def create_test_social_collection_exercise(context, survey_id, period, ru_ref, c
     return iac
 
 
-def create_test_business_collection_exercise(survey_id, period, ru_ref, ce_name, survey_type, stop_at_state='LIVE'):
+def create_test_business_collection_exercise(survey_id, period, ru_ref, ce_name, survey_type, stop_at_state='LIVE',
+                                             eq_ci=False):
     """ Creates a new Collection Exercise for the survey supplied """
 
     logger.debug('Creating Business Collection Exercise', survey_id=survey_id, period=period)
@@ -285,7 +294,8 @@ def create_test_business_collection_exercise(survey_id, period, ru_ref, ce_name,
     iac = collection_exercise_controller.create_and_execute_collection_exercise_with_unique_sample(survey_id, period,
                                                                                                    user_description,
                                                                                                    dates, ru_ref,
-                                                                                                   stop_at_state)
+                                                                                                   stop_at_state,
+                                                                                                   eq_ci=eq_ci)
 
     logger.debug('Business Collection Exercise created - ', survey_id=survey_id, ru_ref=ru_ref,
                  user_description=user_description, period=period, dates=dates)

--- a/acceptance_tests/features/steps/access_eq_collection_exercise.py
+++ b/acceptance_tests/features/steps/access_eq_collection_exercise.py
@@ -9,12 +9,11 @@ from controllers import party_controller
 
 @given('the respondent has a CE for an eQ available')
 def respondent_has_eq_ce_available(context):
-    pass
+    surveys_todo.go_to()
 
 
 @when('the respondent accesses the eQ CE')
 def respondent_accesses_eq_ce(context):
-    surveys_todo.go_to()
     surveys_todo.access_survey(context.long_name)
 
 

--- a/acceptance_tests/features/steps/access_eq_collection_exercise.py
+++ b/acceptance_tests/features/steps/access_eq_collection_exercise.py
@@ -9,20 +9,18 @@ from controllers import party_controller
 
 @given('the respondent has a CE for an eQ available')
 def respondent_has_eq_ce_available(context):
-    party_id = party_controller.get_party_by_email(Config.RESPONDENT_USERNAME)['id']
-    # Enrolling for QBS 1806
-    enrol_respondent(party_id, '02b9c366-7397-42f7-942a-76dc5876d86d', '1806')
+    pass
 
 
 @when('the respondent accesses the eQ CE')
-def respondent_accesses_eq_ce(_):
+def respondent_accesses_eq_ce(context):
     surveys_todo.go_to()
-    surveys_todo.access_survey('Quarterly Business Survey')
+    surveys_todo.access_survey(context.long_name)
 
 
 @then('the respondent lands on the correct eQ Homepage for the survey and CE and CI')
 def respondent_redirected_to_eq(_):
     url = browser.url
     assert 'https://eq-test/session?token=' in url, url
-    token = url[30:]
+    token = url.partition('token=')[2]
     assert len(token.split('.')) == 5   # check correct jwt format

--- a/acceptance_tests/features/steps/access_eq_collection_exercise.py
+++ b/acceptance_tests/features/steps/access_eq_collection_exercise.py
@@ -17,7 +17,7 @@ def respondent_accesses_eq_ce(context):
     surveys_todo.access_survey(context.long_name)
 
 
-@then('the respondent lands on the correct eQ Homepage for the survey and CE and CI')
+@then('the respondent is redirected to eQ with a token')
 def respondent_redirected_to_eq(_):
     url = browser.url
     assert 'https://eq-test/session?token=' in url, url

--- a/controllers/collection_instrument_controller.py
+++ b/controllers/collection_instrument_controller.py
@@ -78,3 +78,9 @@ def get_collection_instruments_by_classifier(survey_id=None, form_type=None):
 
     logger.debug('Successfully retrieved collection instruments', survey_id=survey_id, form_type=form_type)
     return json.loads(response.text)
+
+
+def load_and_link_eq_collection_instrument(survey_id, collection_exercise_id, form_type, eq_id):
+    upload_eq_collection_instrument(survey_id, form_type, eq_id)
+    collection_instrument_id = get_collection_instruments_by_classifier(survey_id, form_type)[0]['id']
+    link_collection_instrument_to_exercise(collection_instrument_id, collection_exercise_id)


### PR DESCRIPTION
# Motivation and Context
Converts the access eq collection exercise feature to standalone so it can be run in parallel

# What has changed
- Modified access eq collection exercise steps to use standalone setup data
- Added standalone and setup fixture tags to feature
- Added option to set up default CE data as EQ
- Small refactor of collection exercise setup to allow EQ instruments

# How to test?
Run `make acceptance_tests` locally. They should all pass and the access eq collection exercise feature should be skipped in the sequential run and included in the parallel.

# Links
https://trello.com/c/hqq9j2gf/389-t389-convert-access-eq-collection-exercise-feature-to-standalone

 NB: This branches from refactor branch to avoid merge conflicts, this PR will point to master once that base branch is merged.