### PR TITLE
Standalone account unlocking features

### DIFF
--- a/acceptance_tests/features/account_unlocking_internal.feature
+++ b/acceptance_tests/features/account_unlocking_internal.feature
@@ -1,23 +1,25 @@
+@standalone
+@business
+@fixture.setup.data.with.enrolled.respondent.user.and.internal.user
 Feature: Internal User unlocking Respondent account
   As Internal User
   I need to be able to unlock a respondent's account
   So that the respondent can access their survey account
 
   Background: A respondent has locked their account
-    Given A respondent with an email "locked@email.com" locks their account
-
+    Given a respondent locks their account
+    And the internal user is already signed in
 
   @us203_01
   Scenario: Internal user can view account is locked with an unlock link
-    Given The internal user is already signed in
-    And The internal user navigates to the find RU page
-    When The internal user enters a RU ref
-    Then The internal user can see that the respondent has an account status locked
-    And There is also an unlock link below the locked
+    When the internal user navigates to locked accounts RU page
+    Then the internal user can see that the respondent has an account status locked
+    And there is also an unlock link below the locked
 
   @us203_02
   Scenario: Internal user clicks unlock
-    Given An internal user clicks on the unlock link
-    When They confirm the unlock
-    Then The reporting unit page is reloaded with a change flag
-    And Account status for the respondent is showing as active
+    Given the internal user navigates to locked accounts RU page
+    When an internal user clicks on the unlock link
+    And they confirm the unlock
+    Then the reporting unit page is reloaded with a change flag
+    And account status for the respondent is showing as active

--- a/acceptance_tests/features/environment.py
+++ b/acceptance_tests/features/environment.py
@@ -7,7 +7,7 @@ from structlog import wrap_logger
 
 from acceptance_tests import browser
 from acceptance_tests.features.fixtures import setup_data_survey_with_internal_user, \
-    setup_data_with_2_enrolled_respondent_users_and_internal_user, \
+    setup_data_with_2_enrolled_respondent_users_and_internal_user, setup_data_with_enrolled_respondent_user, \
     setup_data_with_enrolled_respondent_user_and_collection_exercise_to_live, \
     setup_data_with_enrolled_respondent_user_and_internal_user, \
     setup_data_with_enrolled_respondent_user_and_internal_user_and_new_iac_and_collection_exercise_to_live, \
@@ -41,6 +41,8 @@ fixture_scenario_registry = {
         setup_with_internal_user,
     'fixture.setup.data.with.internal.user':
         setup_data_with_internal_user,
+    'fixture.setup.data.with.enrolled.respondent.user':
+        setup_data_with_enrolled_respondent_user,
     'fixture.setup.data.with.enrolled.respondent.user.and.internal.user':
         setup_data_with_enrolled_respondent_user_and_internal_user,
     'fixture.setup.data.with.unenrolled.respondent.user':

--- a/acceptance_tests/features/environment.py
+++ b/acceptance_tests/features/environment.py
@@ -17,8 +17,8 @@ from acceptance_tests.features.fixtures import setup_data_survey_with_internal_u
     setup_data_with_respondent_user_data_and_new_iac, setup_data_with_unenrolled_respondent_user, \
     setup_data_with_unenrolled_respondent_user_and_internal_user, \
     setup_data_with_unenrolled_respondent_user_and_new_iac_and_collection_exercise_to_live, \
-    setup_sequential_data_for_test, setup_survey_metadata_with_internal_user, setup_with_internal_user, \
-    setup_data_with_unverified_respondent
+    setup_data_with_unverified_respondent, setup_sequential_data_for_test, setup_survey_metadata_with_internal_user, \
+    setup_with_internal_user
 from config import Config
 from exceptions import MissingFixtureError
 
@@ -47,7 +47,7 @@ fixture_scenario_registry = {
         setup_data_with_enrolled_respondent_user_and_internal_user,
     'fixture.setup.data.with.unenrolled.respondent.user':
         setup_data_with_unenrolled_respondent_user,
-    'fixture.setup.data.with.unverified.respondent':
+    'fixture.setup.data.with.unverified.respondent.user':
         setup_data_with_unverified_respondent,
     'fixture.setup.data.with.unenrolled.respondent.user.and.internal.user':
         setup_data_with_unenrolled_respondent_user_and_internal_user,

--- a/acceptance_tests/features/environment.py
+++ b/acceptance_tests/features/environment.py
@@ -1,5 +1,4 @@
 import os
-
 from datetime import datetime
 from logging import getLogger
 
@@ -18,7 +17,8 @@ from acceptance_tests.features.fixtures import setup_data_survey_with_internal_u
     setup_data_with_respondent_user_data_and_new_iac, setup_data_with_unenrolled_respondent_user, \
     setup_data_with_unenrolled_respondent_user_and_internal_user, \
     setup_data_with_unenrolled_respondent_user_and_new_iac_and_collection_exercise_to_live, \
-    setup_sequential_data_for_test, setup_survey_metadata_with_internal_user, setup_with_internal_user
+    setup_sequential_data_for_test, setup_survey_metadata_with_internal_user, setup_with_internal_user, \
+    setup_data_with_enrolled_respondent_user
 from config import Config
 from exceptions import MissingFixtureError
 
@@ -45,6 +45,8 @@ fixture_scenario_registry = {
         setup_data_with_enrolled_respondent_user_and_internal_user,
     'fixture.setup.data.with.unenrolled.respondent.user':
         setup_data_with_unenrolled_respondent_user,
+    'fixture.setup.data.with.enrolled.respondent.user':
+        setup_data_with_enrolled_respondent_user,
     'fixture.setup.data.with.unenrolled.respondent.user.and.internal.user':
         setup_data_with_unenrolled_respondent_user_and_internal_user,
     'fixture.setup.data.with.respondent.user.data.and.new.iac':
@@ -77,7 +79,7 @@ def before_all(_):
         except Exception as e:
             # Don't ignore other errors
             raise e
-            
+
     # Run all tests using original method - standalone tests run in sequence
     if not is_ignore_sequential_data_setup():
         setup_sequential_data_for_test()

--- a/acceptance_tests/features/environment.py
+++ b/acceptance_tests/features/environment.py
@@ -18,7 +18,7 @@ from acceptance_tests.features.fixtures import setup_data_survey_with_internal_u
     setup_data_with_unenrolled_respondent_user_and_internal_user, \
     setup_data_with_unenrolled_respondent_user_and_new_iac_and_collection_exercise_to_live, \
     setup_sequential_data_for_test, setup_survey_metadata_with_internal_user, setup_with_internal_user, \
-    setup_data_with_enrolled_respondent_user
+    setup_data_with_unverified_respondent
 from config import Config
 from exceptions import MissingFixtureError
 
@@ -47,8 +47,8 @@ fixture_scenario_registry = {
         setup_data_with_enrolled_respondent_user_and_internal_user,
     'fixture.setup.data.with.unenrolled.respondent.user':
         setup_data_with_unenrolled_respondent_user,
-    'fixture.setup.data.with.enrolled.respondent.user':
-        setup_data_with_enrolled_respondent_user,
+    'fixture.setup.data.with.unverified.respondent':
+        setup_data_with_unverified_respondent,
     'fixture.setup.data.with.unenrolled.respondent.user.and.internal.user':
         setup_data_with_unenrolled_respondent_user_and_internal_user,
     'fixture.setup.data.with.respondent.user.data.and.new.iac':

--- a/acceptance_tests/features/fixtures.py
+++ b/acceptance_tests/features/fixtures.py
@@ -6,8 +6,8 @@ from common.collection_exercise_utilities import create_business_survey_period, 
     generate_new_enrolment_code_from_existing_code, make_user_description
 from common.internal_user_utilities import create_internal_user_login_account
 from common.respondent_utilities import create_enrolled_respondent_for_the_test_survey, create_respondent, \
-    create_respondent_data, create_respondent_email_address, create_respondent_user_login_account, \
-    create_ru_reference, create_unenrolled_respondent, register_respondent, create_unverified_respondent
+    create_respondent_data, create_respondent_email_address, create_respondent_user_login_account, create_ru_reference, \
+    create_unenrolled_respondent, create_unverified_respondent, register_respondent
 from common.survey_utilities import create_survey_reference, create_test_survey, format_survey_name, is_social_survey, \
     logger
 from config import Config

--- a/acceptance_tests/features/fixtures.py
+++ b/acceptance_tests/features/fixtures.py
@@ -81,11 +81,6 @@ def setup_data_with_unenrolled_respondent_user(context):
 
 @fixture
 def setup_data_with_enrolled_respondent_user(context):
-    """
-    Creates default data + an unenrolled Respondent
-    :param context:
-    :return:
-    """
     create_default_data(context)
     create_enrolled_respondent_for_the_test_survey(context)
 

--- a/acceptance_tests/features/fixtures.py
+++ b/acceptance_tests/features/fixtures.py
@@ -80,6 +80,17 @@ def setup_data_with_unenrolled_respondent_user(context):
 
 
 @fixture
+def setup_data_with_enrolled_respondent_user(context):
+    """
+    Creates default data + an unenrolled Respondent
+    :param context:
+    :return:
+    """
+    create_default_data(context)
+    create_enrolled_respondent_for_the_test_survey(context)
+
+
+@fixture
 def setup_data_with_unenrolled_respondent_user_and_internal_user(context):
     setup_data_with_internal_user(context)
     create_unenrolled_respondent(context)

--- a/acceptance_tests/features/fixtures.py
+++ b/acceptance_tests/features/fixtures.py
@@ -47,6 +47,12 @@ def setup_data_with_internal_user(context):
 
 
 @fixture
+def setup_data_with_enrolled_respondent_user(context):
+    create_default_data(context)
+    create_enrolled_respondent_for_the_test_survey(context)
+
+
+@fixture
 def setup_data_with_internal_user_and_social_collection_exercise_to_closed_status(context):
     """ Creates a collection exercise that has mandatory dates in the past """
     context.period_offset_days = -365

--- a/acceptance_tests/features/fixtures.py
+++ b/acceptance_tests/features/fixtures.py
@@ -80,12 +80,6 @@ def setup_data_with_unenrolled_respondent_user(context):
 
 
 @fixture
-def setup_data_with_enrolled_respondent_user(context):
-    create_default_data(context)
-    create_enrolled_respondent_for_the_test_survey(context)
-
-
-@fixture
 def setup_data_with_unenrolled_respondent_user_and_internal_user(context):
     setup_data_with_internal_user(context)
     create_unenrolled_respondent(context)

--- a/acceptance_tests/features/fixtures.py
+++ b/acceptance_tests/features/fixtures.py
@@ -7,7 +7,7 @@ from common.collection_exercise_utilities import create_business_survey_period, 
 from common.internal_user_utilities import create_internal_user_login_account
 from common.respondent_utilities import create_enrolled_respondent_for_the_test_survey, create_respondent, \
     create_respondent_data, create_respondent_email_address, create_respondent_user_login_account, \
-    create_ru_reference, create_unenrolled_respondent, register_respondent
+    create_ru_reference, create_unenrolled_respondent, register_respondent, create_unverified_respondent
 from common.survey_utilities import create_survey_reference, create_test_survey, format_survey_name, is_social_survey, \
     logger
 from config import Config
@@ -184,6 +184,12 @@ def setup_data_with_2_enrolled_respondent_users_and_internal_user(context):
     context.used_email_address = create_respondent_email_address(second_ru_ref)
     create_respondent(context.used_email_address, new_iac, context.phone_number)
     create_respondent_user_login_account(context.used_email_address)
+
+
+@fixture
+def setup_data_with_unverified_respondent(context):
+    create_default_data(context)
+    create_unverified_respondent(context)
 
 
 def create_internal_user(context):

--- a/acceptance_tests/features/forgotten_password_respondent.feature
+++ b/acceptance_tests/features/forgotten_password_respondent.feature
@@ -1,58 +1,71 @@
+@standalone
+@business
 Feature: External user recovering their password
   As an external user
   I need to sign in to the retrieve my password
   So that I can access my SDC account and carry out a number of actions
 
-  Background: A respondent has to have created an account
-    Given The respondent has created an account which is unverified called "unverified1@email.com"
+  Background: A respondent has to have locked themselves out of their
+    Given the respondent has locked themselves out of their account
 
+  @fixture.setup.data.with.enrolled.respondent.user
   Scenario: User attempts to sign in and has forgotten their password
-    Given The user has an active account and they have forgotten their password
-    When They enter a registered email address
-    Then The user is notified that they have had a password reset link email sent to them
+    Given the user has an active account and they have forgotten their password
+    When they enter a registered email address
+    Then the user is notified that they have had a password reset link email sent to them
 
   Scenario: User attempts to sign in and has forgotten their password attempting to reset with it with an invalid email
-    Given The user has an active account and they have forgotten their password
-    When They enter a invalid email address
-    Then The user is notified that a valid email address is required
+    Given the user has an active account and they have forgotten their password
+    When they enter a invalid email address
+    Then the user is notified that a valid email address is required
 
   Scenario: User attempts to sign in and has forgotten their password attempting to reset with it with an unregistered email
-    Given The user has an active account and they have forgotten their password
-    When They enter a unregistered email address
-    Then The user is notified that they have had a password reset link email sent to them
+    Given the user has an active account and they have forgotten their password
+    When they enter a unregistered email address
+    Then the user is notified that they have had a password reset link email sent to them
 
   Scenario: User attempts to reset password with an expired link
-    Given The user has received an expired link for the reset password form
-    When They click a expired link
-    Then The user is notified that the link has expired
-    And Can now request a new link
+    Given the user has received an expired link for the reset password form
+    When they click a expired link
+    Then the user is notified that the link has expired
+    And can now request a new link
 
+  @fixture.setup.data.with.enrolled.respondent.user
   Scenario: User re-sends reset password link
-    Given The user has been notified that the link they used has expired
-    When They click the request new password link
-    Then The user is notified that they should check their email
+    Given the user has clicked an expired password reset link
+    And the user has been notified that the link they used has expired
+    When they click the request new password link
+    Then the user is notified that they should check their email
 
+  @fixture.setup.data.with.enrolled.respondent.user
   Scenario: User clicks a reset password link
-    Given A user has received a link to reset password
-    When "unverified1@email.com" clicks the link
-    Then The user is taken to a reset password form
+    Given the user has received a link to reset password
+    When the user clicks the link
+    Then the user is taken to a reset password form
 
+  @fixture.setup.data.with.enrolled.respondent.user
   Scenario: User attempts to reset password with incorrect confirmed password
-    Given The user has entered a new password and an incorrect confirmed password
-    When They submit the new password
-    Then The user is notified that the passwords don't match
+    Given the user has clicked a valid password reset link
+    When the user enters a new password and an incorrect confirmed password
+    And they submit the new password
+    Then the user is notified that the passwords don't match
 
+  @fixture.setup.data.with.enrolled.respondent.user
   Scenario: User attempts to reset password with password not meeting requirements
-    Given The user has entered a new password and confirmed the password which does not meet requirements
-    When They submit the new password
-    Then The user is notified that the password does not meet requirements
+    Given the user has clicked a valid password reset link
+    When the user enters and confirms a new password which does not meet requirements
+    And they submit the new password
+    Then the user is notified that the password does not meet requirements
 
+  @fixture.setup.data.with.enrolled.respondent.user
   Scenario: User attempts to reset password
-    Given The user has entered a new password and confirmed the password
-    When They submit the new password
-    Then The user is notified that the password has been changed
+    Given the user has clicked a valid password reset link
+    When the user enters a new password and confirms the password
+    And they submit the new password
+    Then the user is notified that the password has been changed
 
+  @fixture.setup.data.with.enrolled.respondent.user
   Scenario: User logs in with new password
-    Given The user has reset their password
-    When  "unverified1@email.com" enters their credentials
-    Then They successfully log in to their account
+    Given the user has reset their password
+    When the user enters their new credentials
+    Then they successfully log in to their account

--- a/acceptance_tests/features/forgotten_password_respondent.feature
+++ b/acceptance_tests/features/forgotten_password_respondent.feature
@@ -5,7 +5,7 @@ Feature: External user recovering their password
   I need to sign in to the retrieve my password
   So that I can access my SDC account and carry out a number of actions
 
-  Background: A respondent has to have locked themselves out of their
+  Background: A respondent has to have locked themselves out of their account
     Given the respondent has locked themselves out of their account
 
   @fixture.setup.data.with.enrolled.respondent.user

--- a/acceptance_tests/features/pages/forgotten_password_respondent.py
+++ b/acceptance_tests/features/pages/forgotten_password_respondent.py
@@ -1,5 +1,5 @@
 from acceptance_tests import browser
-from common.generate_token import generate_expired_email_token
+from common.generate_token import generate_expired_email_token, generate_email_token
 from config import Config
 
 
@@ -28,6 +28,11 @@ def go_to_expired_password_request_url(context):
     expired_token = generate_expired_email_token(context.respondent_email)
     url = f'{Config.FRONTSTAGE_SERVICE}/passwords/reset-password/{expired_token}'
     browser.visit(url)
+
+
+def get_password_reset_url(context):
+    token = generate_email_token(context.respondent_email)
+    return f'{Config.FRONTSTAGE_SERVICE}/passwords/reset-password/{token}'
 
 
 def get_expired_message():

--- a/acceptance_tests/features/pages/forgotten_password_respondent.py
+++ b/acceptance_tests/features/pages/forgotten_password_respondent.py
@@ -1,4 +1,5 @@
 from acceptance_tests import browser
+from common.generate_token import generate_expired_email_token
 from config import Config
 
 
@@ -7,8 +8,8 @@ def go_to_forgot_password_url():
     browser.find_link_by_href('/passwords/forgot-password').click()
 
 
-def enter_username(username):
-    browser.driver.find_element_by_id('email_address').send_keys(username)
+def enter_email_address(email_address):
+    browser.driver.find_element_by_id('email_address').send_keys(email_address)
 
 
 def send_reset_link():
@@ -23,9 +24,9 @@ def check_email_error_message():
     return browser.find_by_text('Invalid email address')
 
 
-def go_to_expired_password_request_url():
-    url = f'{Config.FRONTSTAGE_SERVICE}/passwords/reset-password/InVudmVyaWZpZWQxQGVtYWlsLmNvbSI.DoOicQ.Fi4dkj3J1C' \
-          '41Ehd4qNhnOdsZELc'
+def go_to_expired_password_request_url(context):
+    expired_token = generate_expired_email_token(context.respondent_email)
+    url = f'{Config.FRONTSTAGE_SERVICE}/passwords/reset-password/{expired_token}'
     browser.visit(url)
 
 

--- a/acceptance_tests/features/pages/forgotten_password_respondent.py
+++ b/acceptance_tests/features/pages/forgotten_password_respondent.py
@@ -26,8 +26,7 @@ def check_email_error_message():
 
 def go_to_expired_password_request_url(context):
     expired_token = generate_expired_email_token(context.respondent_email)
-    url = f'{Config.FRONTSTAGE_SERVICE}/passwords/reset-password/{expired_token}'
-    browser.visit(url)
+    browser.visit(f'{Config.FRONTSTAGE_SERVICE}/passwords/reset-password/{expired_token}')
 
 
 def get_password_reset_url(context):

--- a/acceptance_tests/features/pages/forgotten_password_respondent.py
+++ b/acceptance_tests/features/pages/forgotten_password_respondent.py
@@ -1,5 +1,5 @@
 from acceptance_tests import browser
-from common.generate_token import generate_expired_email_token, generate_email_token
+from common.generate_token import generate_email_token, generate_expired_email_token
 from config import Config
 
 

--- a/acceptance_tests/features/pages/respondent_unlocking_account.py
+++ b/acceptance_tests/features/pages/respondent_unlocking_account.py
@@ -11,14 +11,6 @@ def creating_unverified_account(username):
                             username=username, ru_ref=49900000001, verified=False)
 
 
-def create_locked_account(username):
-    email_in_use = get_party_by_email(username)
-    if not email_in_use:
-        register_respondent(survey_id='cb8accda-6118-4d3b-85a3-149e28960c54', period='201801',
-                            username=username, ru_ref=49900000005)
-        locking_respondent_out(username)
-
-
 def respondent_enters_wrong_password(username):
     sign_in_respondent.go_to()
     browser.driver.find_element_by_id('username').send_keys(username)
@@ -31,7 +23,7 @@ def locking_respondent_out(username):
         respondent_enters_wrong_password(username=username)
 
 
-def get_lockout_message(_):
+def get_lockout_message():
     return browser.find_by_text("You've tried to sign in a few times with the wrong details.")
 
 

--- a/acceptance_tests/features/pages/respondent_verification.py
+++ b/acceptance_tests/features/pages/respondent_verification.py
@@ -8,7 +8,7 @@ def enter_credentials(username, password):
     browser.driver.find_element_by_id('inputPassword').send_keys(password)
 
 
-def log_in_respondent():
+def click_sign_in_button():
     browser.find_by_id('sign_in_button').click()
 
 

--- a/acceptance_tests/features/respondent_unlocking_account.feature
+++ b/acceptance_tests/features/respondent_unlocking_account.feature
@@ -1,5 +1,6 @@
 @standalone
 @business
+@fixture.setup.data.with.unverified.respondent.user
 Feature: Respondent unlocking their account
   As a respondent
   I need to unlock my account, if I exceed 10 failed sign in attempts
@@ -8,17 +9,14 @@ Feature: Respondent unlocking their account
   Background: A respondent has to have created an account
     Given the respondent has locked themselves out of their account
 
-  @fixture.setup.data.with.unenrolled.respondent.user
   Scenario: Unverified user is informed if they exceed 10 failed sign in attempts
     Then The system is to inform the user that an email has been sent to a registered email
 
-  @fixture.setup.data.with.unenrolled.respondent.user
   Scenario: User is sent an email after 10 failed sign in attempts, gets directed to the password reset page
     Given an unverified user has received the unsuccessful sign in email
     When they click the password reset link
     Then they are directed to the reset password page
 
-  @fixture.setup.data.with.unenrolled.respondent.user
   Scenario: Account is unlocked and verified after confirming password reset
     Given an unverified user has received the unsuccessful sign in email
     And they click the password reset link

--- a/acceptance_tests/features/respondent_unlocking_account.feature
+++ b/acceptance_tests/features/respondent_unlocking_account.feature
@@ -1,38 +1,27 @@
+@standalone
+@business
 Feature: Respondent unlocking their account
   As a respondent
   I need to unlock my account, if I exceed 10 failed sign in attempts
   So that I can access my account
 
   Background: A respondent has to have created an account
-    Given The respondent has created an account which is unverified called "locked1@email.com"
-    And The respondent has created an account which is verified called "locked2@email.com"
+    Given the respondent has locked themselves out of their account
 
+  @fixture.setup.data.with.unenrolled.respondent.user
   Scenario: Unverified user is informed if they exceed 10 failed sign in attempts
-    Given "locked1@email.com" enters their password incorrectly 10 times in a row
     Then The system is to inform the user that an email has been sent to a registered email
 
+  @fixture.setup.data.with.unenrolled.respondent.user
   Scenario: User is sent an email after 10 failed sign in attempts, gets directed to the password reset page
-    Given An unverified user has received the unsuccessful sign in email
-    When "locked1@email.com" clicks the link
-    Then They are directed to the reset password page
+    Given an unverified user has received the unsuccessful sign in email
+    When they click the password reset link
+    Then they are directed to the reset password page
 
+  @fixture.setup.data.with.unenrolled.respondent.user
   Scenario: Account is unlocked and verified after confirming password reset
-    Given An Unverified user's account is locked
-    And The user has entered a new password and confirmed the password
-    When They submit the new password
-    Then Their password is reset and their account is unlocked and verified
-
-  Scenario: Verified user is informed if they exceed 10 failed sign in attempts
-    Given "locked2@email.com" enters their password incorrectly 10 times in a row
-    Then The system is to inform the user that an email has been sent to a registered email
-
-  Scenario: User is sent an email after 10 failed sign in attempts
-    Given A verified user has received the unsuccessful sign in email
-    When "locked2@email.com" clicks the link
-    Then They are directed to the reset password page
-
-  Scenario: Account is unlocked after confirming password reset
-    Given A verified user's account is locked
-    And The user has entered a new password and confirmed the password
-    When They confirm their password reset
-    Then Their password is reset and their account is unlocked and verified
+    Given an unverified user has received the unsuccessful sign in email
+    And they click the password reset link
+    When the user enters a new password and confirms the password
+    And they submit the new password
+    Then their password is reset and their account is unlocked and verified

--- a/acceptance_tests/features/respondent_verification.feature
+++ b/acceptance_tests/features/respondent_verification.feature
@@ -1,29 +1,27 @@
+@standalone
+@business
+@fixture.setup.data.with.unverified.respondent
 Feature: notifying respondent to verify their email address
   As an external user
   I need to be notified that I haven't verified my email
   So that I can verify my email address
 
-  Background: A respondent has to have created an account
-    Given The respondent has created an account which is unverified called "unverified2@email.com"
-
   Scenario: Unverified account user is notified to verify their email address
-    Given An external "unverified2@email.com" with unverified account tried to sign into their account
-    When They enter correct credentials
-    Then They are shown on-screen notification to verify their email
-    And They are shown on-screen notification to request a verification link email
+    Given the respondent with unverified account navigates to the sign in page
+    When they enter correct credentials
+    Then they are shown on-screen notification to verify their email
+    And they are shown on-screen notification to request a verification link email
 
   Scenario: Respondent using expired verification link
-    Given A user has an expired verification link
-    When They click the expired verification link
-    Then The user is notified that their link has expired, and given the option to re-send a verification email
+    When the respondent clicks an expired verification link
+    Then the user is notified that their link has expired, and given the option to re-send a verification email
 
   Scenario: User has the ability to re-send their verification email
-    Given A user has been notified their link has expired
-    When They select the re-send verification email link
-    Then They are notified that their verification email has been re-sent
+    Given the respondent has clicked an expired account verification link
+    And the user has been notified their link has expired
+    When they select the re-send verification email link
+    Then they are notified that their verification email has been re-sent
 
   Scenario: Verifying a users account
-    Given A user has received a verification link
-    When They select the verification link in the email "unverified2@email.com"
-    Then The user is taken to a page stating their account has been activated
-
+    When the respondent clicks a valid verification link in the email
+    Then the user is taken to a page stating their account has been activated

--- a/acceptance_tests/features/respondent_verification.feature
+++ b/acceptance_tests/features/respondent_verification.feature
@@ -1,6 +1,6 @@
 @standalone
 @business
-@fixture.setup.data.with.unverified.respondent
+@fixture.setup.data.with.unverified.respondent.user
 Feature: notifying respondent to verify their email address
   As an external user
   I need to be notified that I haven't verified my email

--- a/acceptance_tests/features/steps/account_unlocking_internal.py
+++ b/acceptance_tests/features/steps/account_unlocking_internal.py
@@ -1,32 +1,32 @@
-from behave import given, when, then
+from behave import given, then, when
 
 from acceptance_tests import browser
 from acceptance_tests.features.pages import reporting_unit
-from acceptance_tests.features.pages.respondent_unlocking_account import create_locked_account,\
-    get_lockout_message
+from acceptance_tests.features.pages.respondent_unlocking_account import get_lockout_message, locking_respondent_out
 
 
-@given('a respondent with an email "{username}" locks their account')
-def respondent_account(_, username):
-    create_locked_account(username=username)
+@given('a respondent locks their account')
+def respondent_account(context):
+    locking_respondent_out(username=context.respondent_email)
 
 
 @then('the account will be locked')
 def check_account_locked_externally(_):
-    assert get_lockout_message(_)
+    assert get_lockout_message()
 
 
 @then('the internal user can see that the respondent has an account status locked')
 @then('there is also an unlock link below the locked')
-def check_account_locked_internally(_):
-    reporting_unit.go_to('49900000005')
-    reporting_unit.click_data_panel('Bricks')
+def check_account_locked_internally(context):
+    reporting_unit.go_to(context.short_name)
+    reporting_unit.click_data_panel(context.short_name)
     assert browser.find_by_id('account-status')[0].value == 'Locked'
     assert browser.find_by_id('respondent-unlock-link')[0].value == 'Unlock'
 
 
-@given('an internal user clicks on the unlock link')
-def unlock_account_internally(_):
+@when('an internal user clicks on the unlock link')
+def unlock_account_internally(context):
+    reporting_unit.click_data_panel(context.short_name)
     browser.find_by_id('respondent-unlock-link')[0].click()
 
 
@@ -37,7 +37,7 @@ def confirm_unlock_account_internally(_):
 
 @then('the reporting unit page is reloaded with a change flag')
 @then('account status for the respondent is showing as active')
-def account_status_changed(_):
+def account_status_changed(context):
     assert browser.find_by_id('success')[0].value == 'Account status changed'
-    reporting_unit.click_data_panel('Bricks')
+    reporting_unit.click_data_panel(context.short_name)
     assert browser.find_by_id('account-status')[0].value == 'Active'

--- a/acceptance_tests/features/steps/forgotten_password_respondent.py
+++ b/acceptance_tests/features/steps/forgotten_password_respondent.py
@@ -3,8 +3,6 @@ from behave import given, then, when
 from acceptance_tests import browser
 from acceptance_tests.features.pages import forgotten_password_respondent, sign_in_respondent
 from acceptance_tests.features.pages.forgotten_password_respondent import get_password_reset_url
-from common.generate_token import generate_email_token
-from config import Config
 
 
 @given('the user has an active account and they have forgotten their password')

--- a/acceptance_tests/features/steps/forgotten_password_respondent.py
+++ b/acceptance_tests/features/steps/forgotten_password_respondent.py
@@ -1,4 +1,4 @@
-from behave import given, when, then
+from behave import given, then, when
 
 from acceptance_tests import browser
 from acceptance_tests.features.pages import forgotten_password_respondent, sign_in_respondent
@@ -12,18 +12,18 @@ def go_to_forgotten_password(_):
 
 
 @when('they enter a registered email address')
-def enter_email_address(_):
-    forgotten_password_respondent.enter_username(str(Config.RESPONDENT_USERNAME))
+def enter_email_address(context):
+    forgotten_password_respondent.enter_email_address(context.respondent_email)
 
 
 @when('they enter a invalid email address')
 def enter_invalid_email_address(_):
-    forgotten_password_respondent.enter_username(' ')
+    forgotten_password_respondent.enter_email_address(' ')
 
 
 @when('they enter a unregistered email address')
 def enter_unregistered_email_address(_):
-    forgotten_password_respondent.enter_username('fakeemail@email.com')
+    forgotten_password_respondent.enter_email_address('fakeemail@email.com')
 
 
 @then('the user is notified that they have had a password reset link email sent to them')
@@ -39,9 +39,10 @@ def invalid_email_error_occurred(_):
 
 
 @given('the user has received an expired link for the reset password form')
+@given('the user has clicked an expired password reset link')
 @when('they click a expired link')
-def click_expired_password_link(_):
-    forgotten_password_respondent.go_to_expired_password_request_url()
+def click_expired_password_link(context):
+    forgotten_password_respondent.go_to_expired_password_request_url(context)
 
 
 @then('the user is notified that the link has expired')
@@ -61,16 +62,26 @@ def click_request_new_password_link_(_):
 
 
 @then('the user is notified that they should check their email')
-@given('a user has received a link to reset password')
 def password_reset_request_sent(_):
     assert forgotten_password_respondent.get_request_new_password()
 
 
-@when('"{email}" clicks the link')
-def click_password_reset_link(_, email):
-    token = generate_email_token(email)
+@given('the user has received a link to reset password')
+def user_received_password_reset_link(context):
+    token = generate_email_token(context.respondent_email)
     url = f'{Config.FRONTSTAGE_SERVICE}/passwords/reset-password/{token}'
-    browser.visit(url)
+    context.respondent_password_reset_link = url
+
+
+@when('the user clicks the link')
+def click_password_reset_link(context):
+    browser.visit(context.respondent_password_reset_link)
+
+
+@given('the user has clicked a valid password reset link')
+def user_navigates_to_valid_password_reset(context):
+    user_received_password_reset_link(context)
+    click_password_reset_link(context)
 
 
 @then('the user is taken to a reset password form')
@@ -78,7 +89,7 @@ def get_password_reset_form(_):
     assert forgotten_password_respondent.get_reset_password_message()
 
 
-@given('the user has entered a new password and an incorrect confirmed password')
+@when('the user enters a new password and an incorrect confirmed password')
 def entering_in_invalid_passwords(_):
     forgotten_password_respondent.enter_in_passwords('Password1!', 'Password')
 
@@ -93,18 +104,17 @@ def passwords_is_invalid(_):
     assert forgotten_password_respondent.get_passwords_do_not_match_message()
 
 
-@given('the user has entered a new password and confirmed the password')
+@when('the user enters a new password and confirms the password')
 def entering_in_valid_passwords(_):
     forgotten_password_respondent.enter_in_passwords('Password1!', 'Password1!')
 
 
 @then('the user is notified that the password has been changed')
-@given('the user has reset their password')
-def password_changed(_):
+def confirm_password_changed_message(_):
     assert forgotten_password_respondent.get_password_changed_message()
 
 
-@given('the user has entered a new password and confirmed the password which does not meet requirements')
+@when('the user enters and confirms a new password which does not meet requirements')
 def entering_passwords_does_not_meet_requirements(_):
     forgotten_password_respondent.enter_in_passwords('password', 'password')
 
@@ -114,10 +124,18 @@ def password_does_not_meet_requirements(_):
     assert forgotten_password_respondent.get_password_requirements_message()
 
 
-@when('"{username}" enters their credentials')
-def respondent_logs_into_account(_, username):
+@given('the user has reset their password')
+def user_have_reset_their_password(context):
+    user_received_password_reset_link(context)
+    user_navigates_to_valid_password_reset(context)
+    forgotten_password_respondent.enter_in_passwords('Password1!', 'Password1!')
+    forgotten_password_respondent.click_confirm_new_password()
+
+
+@when('the user enters their new credentials')
+def respondent_logs_into_account(context):
     sign_in_respondent.go_to()
-    browser.driver.find_element_by_id('username').send_keys(username)
+    browser.driver.find_element_by_id('username').send_keys(context.respondent_email)
     browser.driver.find_element_by_id('inputPassword').send_keys('Password1!')
     browser.find_by_id('sign_in_button').click()
 

--- a/acceptance_tests/features/steps/forgotten_password_respondent.py
+++ b/acceptance_tests/features/steps/forgotten_password_respondent.py
@@ -2,6 +2,7 @@ from behave import given, then, when
 
 from acceptance_tests import browser
 from acceptance_tests.features.pages import forgotten_password_respondent, sign_in_respondent
+from acceptance_tests.features.pages.forgotten_password_respondent import get_password_reset_url
 from common.generate_token import generate_email_token
 from config import Config
 
@@ -68,9 +69,7 @@ def password_reset_request_sent(_):
 
 @given('the user has received a link to reset password')
 def user_received_password_reset_link(context):
-    token = generate_email_token(context.respondent_email)
-    url = f'{Config.FRONTSTAGE_SERVICE}/passwords/reset-password/{token}'
-    context.respondent_password_reset_link = url
+    context.respondent_password_reset_link = get_password_reset_url(context)
 
 
 @when('the user clicks the link')

--- a/acceptance_tests/features/steps/respondent_unlocking_account.py
+++ b/acceptance_tests/features/steps/respondent_unlocking_account.py
@@ -1,9 +1,10 @@
 from behave import given, then, when
 
+from acceptance_tests import browser
 from acceptance_tests.features.pages import forgotten_password_respondent, reporting_unit
+from acceptance_tests.features.pages.forgotten_password_respondent import get_password_reset_url
 from acceptance_tests.features.pages.respondent_unlocking_account import get_lockout_message, locking_respondent_out, \
     respondent_password_reset_complete
-from acceptance_tests.features.steps.edit_respondent_details import create_respondent
 
 
 @given('the respondent has locked themselves out of their account')
@@ -11,14 +12,15 @@ def respondent_unverified_account(context):
     locking_respondent_out(context.respondent_email)
 
 
-@given('the respondent has created an account which is verified called "{username}"')
-def respondent_account(_, username):
-    create_respondent(username)
+@given('they click the password reset link')
+@when('they click the password reset link')
+def user_clicks_password_reset_link(context):
+    browser.visit(get_password_reset_url(context))
 
 
-@given('"{username}" enters their password incorrectly 10 times in a row')
-def locking_respondent_out_of_account(_, username):
-    locking_respondent_out(username)
+@given('the respondent enters their password incorrectly 10 times in a row')
+def locking_respondent_out_of_account(context):
+    locking_respondent_out(context.respondent_email)
 
 
 @given('the internal user navigates to locked accounts RU page')
@@ -27,29 +29,29 @@ def enter_locked_accounts_ru_ref(context):
     reporting_unit.go_to(context.short_name)
 
 
-@then('The system is to inform the user that an email has been sent to a registered email')
-@given('An unverified user has received the unsuccessful sign in email')
-@given('A verified user has received the unsuccessful sign in email')
+@then('the system is to inform the user that an email has been sent to a registered email')
+@given('an unverified user has received the unsuccessful sign in email')
+@given('a verified user has received the unsuccessful sign in email')
 def lock_out_page(_):
     assert get_lockout_message()
 
 
-@then('They are directed to the reset password page')
+@then('they are directed to the reset password page')
 def get_password_reset_page(_):
     assert forgotten_password_respondent.get_reset_password_message()
 
 
-@given('An Unverified user\'s account is locked')
-@given('A verified user\'s account is locked')
+@given('an Unverified user\'s account is locked')
+@given('a verified user\'s account is locked')
 def users_account_is_locked(_):
     pass
 
 
-@then('Their password is reset and their account is unlocked and verified')
+@then('their password is reset and their account is unlocked and verified')
 def password_reset_complete(_):
     assert respondent_password_reset_complete()
 
 
-@when('They confirm their password reset')
+@when('they confirm their password reset')
 def submitting_password(_):
     forgotten_password_respondent.click_confirm_new_password()

--- a/acceptance_tests/features/steps/respondent_unlocking_account.py
+++ b/acceptance_tests/features/steps/respondent_unlocking_account.py
@@ -1,14 +1,14 @@
-from behave import given, when, then
+from behave import given, then, when
 
-from acceptance_tests.features.pages import forgotten_password_respondent
-from acceptance_tests.features.pages.respondent_unlocking_account import creating_unverified_account,\
-    get_lockout_message, respondent_password_reset_complete, locking_respondent_out
+from acceptance_tests.features.pages import forgotten_password_respondent, reporting_unit
+from acceptance_tests.features.pages.respondent_unlocking_account import get_lockout_message, locking_respondent_out, \
+    respondent_password_reset_complete
 from acceptance_tests.features.steps.edit_respondent_details import create_respondent
 
 
 @given('the respondent has created an account which is unverified called "{username}"')
-def respondent_unverified_account(_, username):
-    creating_unverified_account(username=username)
+def respondent_unverified_account(context, username):
+    locking_respondent_out(context.respdonent_email)
 
 
 @given('the respondent has created an account which is verified called "{username}"')
@@ -21,11 +21,17 @@ def locking_respondent_out_of_account(_, username):
     locking_respondent_out(username)
 
 
+@given('the internal user navigates to locked accounts RU page')
+@when('the internal user navigates to locked accounts RU page')
+def enter_locked_accounts_ru_ref(context):
+    reporting_unit.go_to(context.short_name)
+
+
 @then('The system is to inform the user that an email has been sent to a registered email')
 @given('An unverified user has received the unsuccessful sign in email')
 @given('A verified user has received the unsuccessful sign in email')
 def lock_out_page(_):
-    assert get_lockout_message(_)
+    assert get_lockout_message()
 
 
 @then('They are directed to the reset password page')

--- a/acceptance_tests/features/steps/respondent_unlocking_account.py
+++ b/acceptance_tests/features/steps/respondent_unlocking_account.py
@@ -6,9 +6,9 @@ from acceptance_tests.features.pages.respondent_unlocking_account import get_loc
 from acceptance_tests.features.steps.edit_respondent_details import create_respondent
 
 
-@given('the respondent has created an account which is unverified called "{username}"')
-def respondent_unverified_account(context, username):
-    locking_respondent_out(context.respdonent_email)
+@given('the respondent has locked themselves out of their account')
+def respondent_unverified_account(context):
+    locking_respondent_out(context.respondent_email)
 
 
 @given('the respondent has created an account which is verified called "{username}"')

--- a/common/generate_token.py
+++ b/common/generate_token.py
@@ -22,10 +22,6 @@ def generate_email_token(email):
 
 
 class ExpiredTimestampSigner(TimestampSigner):
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
     def get_timestamp(self):
         # Make the signature timestamp a year old
         return int(time.time()) - 60 * 60 * 24 * 365

--- a/common/generate_token.py
+++ b/common/generate_token.py
@@ -1,20 +1,42 @@
-from itsdangerous import URLSafeTimedSerializer
+import time
 from logging import getLogger
 
-import config
+from itsdangerous import TimestampSigner, URLSafeTimedSerializer
 from structlog import wrap_logger
 
+from config import Config
 
 logger = wrap_logger(getLogger(__name__))
 
 
 def generate_email_token(email):
-    secret_key = config.Config.SECRET_KEY
-    email_token_salt = config.Config.EMAIL_TOKEN_SALT
+    secret_key = Config.SECRET_KEY
+    email_token_salt = Config.EMAIL_TOKEN_SALT
 
     if secret_key is None or email_token_salt is None:
         msg = "SECRET_KEY or EMAIL_TOKEN_SALT are not configured."
         logger.error(msg)
 
     timed_serializer = URLSafeTimedSerializer(secret_key)
+    return timed_serializer.dumps(email, salt=email_token_salt)
+
+
+class ExpiredTimestampSigner(TimestampSigner):
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def get_timestamp(self):
+        # Make the signature timestamp a year old
+        return int(time.time()) - 60 * 60 * 24 * 365
+
+
+def generate_expired_email_token(email):
+    secret_key = Config.SECRET_KEY
+    email_token_salt = Config.EMAIL_TOKEN_SALT
+
+    if secret_key is None or email_token_salt is None:
+        msg = "SECRET_KEY or EMAIL_TOKEN_SALT are not configured."
+        logger.error(msg)
+    timed_serializer = URLSafeTimedSerializer(secret_key, signer=ExpiredTimestampSigner)
     return timed_serializer.dumps(email, salt=email_token_salt)

--- a/common/respondent_utilities.py
+++ b/common/respondent_utilities.py
@@ -16,8 +16,9 @@ TELEPHONE_NUMBER_END = 99999999999
 logger = wrap_logger(getLogger(__name__))
 
 
-def create_respondent(user_name, enrolment_code, phone_number):
-    logger.debug('Creating a respondent', username=user_name, enrolment_code=enrolment_code, phone_number=phone_number)
+def create_respondent(user_name, enrolment_code, phone_number, activate=True):
+    logger.debug('Creating a respondent', username=user_name, enrolment_code=enrolment_code, phone_number=phone_number,
+                 activate=activate)
 
     # party_controller.register_respondent endpoint performs many tasks including survey enrolment (which is not always
     # needed and can be rolled back using the unenrol_respondent_in_survey() method)
@@ -28,10 +29,11 @@ def create_respondent(user_name, enrolment_code, phone_number):
                                                       phone_number=phone_number,
                                                       enrolment_code=enrolment_code)
     respondent_id = respondent['id']
+    if activate:
+        party_controller.change_respondent_status(respondent_id)
 
-    party_controller.change_respondent_status(respondent_id)
-
-    logger.debug('Respondent created', respondent_id=respondent_id, username=user_name, enrolment_code=enrolment_code)
+    logger.debug('Respondent created', respondent_id=respondent_id, username=user_name, enrolment_code=enrolment_code,
+                 activate=activate)
 
     return respondent
 
@@ -110,6 +112,12 @@ def create_unenrolled_respondent(context):
     create_respondent_user_login_account(context.respondent_email)
 
     unenrol_respondent_in_survey(context.survey_id)
+
+
+def create_unverified_respondent(context):
+    create_respondent_data(context)
+    create_respondent(user_name=context.respondent_email, enrolment_code=context.iac, phone_number=context.phone_number,
+                      activate=False)
 
 
 def make_email_address(local_part=None, domain=None):


### PR DESCRIPTION
# Motivation and Context
Converts the respondent account locking and unlocking related scenarios to standalone so they can be run in parallel. Also deletes 3 scenarios from the 'respondent_unlocks_account.feature' because they are duplicates from another feature file.

# What has changed
- Convert account unlocking internal feature to standalone
- Convert forgotten password respondent feature to standalone
- Convert respondent unlocking account feature to standalone
- Convert respondent verification feature to standalone
- Delete duplicate tests in respondent unlocking account
- Add function to generate a year old timestamped email reset JWT

# How to test?
Run `make acceptance_tests`
All tests should pass and the listed feature should now not run in the sequential batch and run in the parallel batch.

# Links
https://trello.com/c/LraNWdPy/396-t396-convert-account-unlocking-features-to-standalone
