### PR TITLE
Return user to page when closing conversation

### DIFF
--- a/acceptance_tests/features/reply_to_message_internal.feature
+++ b/acceptance_tests/features/reply_to_message_internal.feature
@@ -67,3 +67,19 @@ Feature: Reply to message internal
     Given the internal user has a conversation in their inbox
     When they view the message
     Then they are able to see the messages in the conversation in chronological order
+
+  @sm599_s01
+  Scenario: When closing a conversation the user should be returned to the same page
+    Given the user has got '30' messages in their inbox
+    And the secure message user is on page '2'
+    When they close the conversation
+    Then they are taken back to page '2'
+    And they receive confirmation that the conversation is closed
+
+  @sm599_s02
+  Scenario: When closing the only conversation on the final page the user should be returned to the new final page
+    Given the user has got '21' messages in their inbox
+    And the secure message user is on page '3'
+    When they close the conversation
+    Then they are taken back to page '2'
+    And they receive confirmation that the conversation is closed

--- a/acceptance_tests/features/send_message_from_todo_list.feature
+++ b/acceptance_tests/features/send_message_from_todo_list.feature
@@ -2,7 +2,6 @@
 @standalone
 @secure_messaging
 @fixture.setup.data.with.enrolled.respondent.user.and.internal.user.and.new.iac.and.collection.exercise.to.live
-@wip
 Feature: Send message from todo list
   As a Respondent
   I need to be able to send a secure message in relation to an RU and a survey in my todo list

--- a/acceptance_tests/features/steps/reply_to_message_internal.py
+++ b/acceptance_tests/features/steps/reply_to_message_internal.py
@@ -9,7 +9,6 @@ from acceptance_tests.features.pages import inbox_internal
 from acceptance_tests.features.pages.internal_conversation_view import go_to_thread
 from acceptance_tests.features.pages.reply_to_message_internal import get_current_url
 from acceptance_tests.features.steps.authentication import signed_in_internal
-from acceptance_tests.features.steps.inbox_internal import populate_database_with_number_of_messages
 from controllers.messages_controller import create_message_external_to_internal, \
     create_and_close_message_internal_to_external
 

--- a/acceptance_tests/features/steps/reply_to_message_internal.py
+++ b/acceptance_tests/features/steps/reply_to_message_internal.py
@@ -1,3 +1,4 @@
+import time
 from datetime import datetime
 
 from behave import given, when, then
@@ -8,6 +9,7 @@ from acceptance_tests.features.pages import inbox_internal
 from acceptance_tests.features.pages.internal_conversation_view import go_to_thread
 from acceptance_tests.features.pages.reply_to_message_internal import get_current_url
 from acceptance_tests.features.steps.authentication import signed_in_internal
+from acceptance_tests.features.steps.inbox_internal import populate_database_with_number_of_messages
 from controllers.messages_controller import create_message_external_to_internal, \
     create_and_close_message_internal_to_external
 
@@ -109,3 +111,19 @@ def messages_in_chronological_order(_):
     first_message_date = datetime.strptime(browser.find_by_id('sm-sent-date-1').value.split(' ')[2], '%H:%M')
     second_message_date = datetime.strptime(browser.find_by_id('sm-sent-date-2').value.split(' ')[2], '%H:%M')
     assert first_message_date <= second_message_date
+
+
+@given("the secure message user is on page '{page}'")
+def user_on_page(context, page):
+    inbox_internal.go_to_using_context(context)
+
+    for index in range(1, int(page)):
+        browser.driver.find_element_by_class_name('next').click()
+        time.sleep(5)
+
+    go_to_thread()
+
+
+@then("they are taken back to page '{page}'")
+def taken_back_to_page(context, page):
+    assert f'page={page}' in browser.url


### PR DESCRIPTION
# Motivation and Context
When a Response-Ops UI user closes a secure message conversation, they should be returned to the inbox page they were on before they closed the conversation.

# What has changed
Added tests for improved functionality.

# How to test?
Run the scenarios `@sm599_s01` and `@sm599_s02` or the whole acceptance test suite, against the `response-operations-ui' branch of the same name.

# Links
Trello: https://trello.com/c/lCfPjUPT