### PR TITLE
Added test that respondent now replies to a specific internal user

### DIFF
--- a/acceptance_tests/features/steps/inbox_internal.py
+++ b/acceptance_tests/features/steps/inbox_internal.py
@@ -128,6 +128,6 @@ def closed_tab_is_visible(_):
 
 
 @then('The To field should be the name of the internal user who sent the message')
-def to_filed_holds_name_of_internal_user_who_sent_the_message(context):
+def to_field_holds_name_of_internal_user_who_sent_the_message(context):
     first_message = inbox_internal.get_unread_messages()[0]
     assert f"{context.internal_user_name} {context.internal_user_name}" in first_message.text

--- a/acceptance_tests/features/steps/inbox_internal.py
+++ b/acceptance_tests/features/steps/inbox_internal.py
@@ -38,6 +38,7 @@ def user_has_no_messages_in_inbox(_):
     pass
 
 
+@when('internal user navigate to the inbox messages')
 @when('they navigate to the inbox messages')
 def internal_user_views_messages(context):
     inbox_internal.go_to_using_context(context)
@@ -124,3 +125,9 @@ def pagination_links_available(_):
 @then('they can see the closed tab')
 def closed_tab_is_visible(_):
     assert inbox_internal.closed_tab_present()
+
+
+@then('The To field should be the name of the internal user who sent the message')
+def to_filed_holds_name_of_internal_user_who_sent_the_message(context):
+    first_message = inbox_internal.get_unread_messages()[0]
+    assert f"{context.internal_user_name} {context.internal_user_name}" in first_message.text

--- a/acceptance_tests/features/steps/view_and_reply_conversation_external.py
+++ b/acceptance_tests/features/steps/view_and_reply_conversation_external.py
@@ -105,13 +105,17 @@ def external_user_views_closed_conversation(_):
     page_helpers.go_to_first_closed_conversation_in_message_box()
 
 
-@then('they are able to reply (external)')
-@when('they reply in that conversation')
-def external_user_able_to_reply_to_conversation(_):
+@given('the external user replies to a message')
+def external_user_replies_to_a_message(_):
     page_helpers.go_to_first_conversation_in_message_box()
     page_helpers.enter_text_in_conversation_reply('Reply body from respondent')
     page_helpers.click_reply_send_button()
 
+
+@then('they are able to reply (external)')
+@when('they reply in that conversation')
+def external_user_able_to_reply_to_conversation(_):
+    external_user_replies_to_a_message(_)
     assert "Message sent." in get_first_flashed_message()
 
 

--- a/acceptance_tests/features/view_and_reply_conversation_external.feature
+++ b/acceptance_tests/features/view_and_reply_conversation_external.feature
@@ -76,3 +76,10 @@ Feature: External User Views a Conversation
     When  the user navigates to the external closed inbox messages
     And   they view the closed conversation
     Then they are informed that the conversation is closed
+
+  Scenario: When a respondent replies to a message it is sent to the same internal user that sent the original message
+    Given the external user has conversations in their list
+      And the external user replies to a message
+      And the internal user is already signed in
+    When  internal user navigate to the inbox messages
+    Then  The To field should be the name of the internal user who sent the message


### PR DESCRIPTION
# Motivation and Context
New functionality added in Fronstage to set the msg_to in secure message to a specific internal person when replying to a message from an internal person. So that the internal user can see the name of a person associated with the conversation

# What has changed
New test when a respondent replies to a message from the internal user checking that the msg_to has the expected internal user id

# How to test?
<!--- Describe in detail how you tested your changes. -->
run the new scenario
  Scenario: When a respondent replies to a message it is sent to the same internal user that sent the original message


# Links
 https://trello.com/c/PGjxHXYA