### PR TITLE
'You have already added that survey' Message Test

### DIFF
--- a/acceptance_tests/features/add_a_survey.feature
+++ b/acceptance_tests/features/add_a_survey.feature
@@ -1,3 +1,4 @@
+@wip
 @business
 @standalone
 Feature: Add a survey
@@ -8,6 +9,14 @@ Feature: Add a survey
   Background: User already logged in
     Given the respondent is signed into their account
 
+
+  @fixture.setup.data.with.enrolled.respondent.and.additional.iac
+  Scenario: User is trying to add a survey using a new iac code that they have previously added
+    Given the user has entered a valid enrolment code for a survey they have already added
+    When they continue and confirm that the organisation and survey that they are enrolling for is correct
+    Then the user is notified they have already added the survey
+
+
   @fixture.setup.data.with.unenrolled.respondent.user
   @us334-addSurvey_s01
   Scenario: Select to add new survey
@@ -16,7 +25,7 @@ Feature: Add a survey
 
   @fixture.setup.data.with.unenrolled.respondent.user
   @us334-addSurvey_s02
-  Scenario: Enter the enrolment code
+  Scenario: Enter the enrolment codegit
     When they add a new survey
     Then they are able to enter an enrolment code
 
@@ -47,3 +56,5 @@ Feature: Add a survey
     Given the user has entered a valid enrolment code
     When they navigate to the confirm organisation page and click cancel
     Then the user is navigated back to their "To do" list and they have not enrolled for that survey
+
+

--- a/acceptance_tests/features/environment.py
+++ b/acceptance_tests/features/environment.py
@@ -18,7 +18,8 @@ from acceptance_tests.features.fixtures import setup_data_survey_with_internal_u
     setup_data_with_respondent_user_data_and_new_iac, setup_data_with_unenrolled_respondent_user, \
     setup_data_with_unenrolled_respondent_user_and_internal_user, \
     setup_data_with_unenrolled_respondent_user_and_new_iac_and_collection_exercise_to_live, \
-    setup_sequential_data_for_test, setup_survey_metadata_with_internal_user, setup_with_internal_user
+    setup_sequential_data_for_test, setup_survey_metadata_with_internal_user, setup_with_internal_user, \
+    setup_data_with_enrolled_respondent_and_additional_iac
 from config import Config
 from exceptions import MissingFixtureError
 
@@ -62,7 +63,9 @@ fixture_scenario_registry = {
     'fixture.setup.data.with.2.enrolled.respondent.users.and.internal.user':
         setup_data_with_2_enrolled_respondent_users_and_internal_user,
     'fixture.setup.data.with.enrolled.respondent.user.and.collection.exercise.to.live':
-        setup_data_with_enrolled_respondent_user_and_collection_exercise_to_live
+        setup_data_with_enrolled_respondent_user_and_collection_exercise_to_live,
+    'fixture.setup.data.with.enrolled.respondent.and.additional.iac':
+        setup_data_with_enrolled_respondent_and_additional_iac
 }
 
 

--- a/acceptance_tests/features/fixtures.py
+++ b/acceptance_tests/features/fixtures.py
@@ -174,6 +174,18 @@ def setup_data_with_2_enrolled_respondent_users_and_internal_user(context):
     create_respondent_user_login_account(context.used_email_address)
 
 
+@fixture
+def setup_data_with_enrolled_respondent_and_additional_iac(context):
+    """ Creates a new enrolled user and generates an additional IAC code """
+    setup_data_with_internal_user(context)
+    create_enrolled_respondent_for_the_test_survey(context)
+    create_new_iac(context)
+    collection_exercise_controller.wait_for_collection_exercise_state(context.survey_id, context.period,
+                                                                      expected_state=COLLECTION_EXERCISE_STATUS_LIVE)
+    context.add_cleanup(sign_out_internal.try_sign_out)
+    context.second_iac = generate_new_enrolment_code_from_existing_code(context.iac)
+
+
 def create_internal_user(context):
     context.internal_user_name = create_ru_reference()
 

--- a/acceptance_tests/features/steps/add_a_survey.py
+++ b/acceptance_tests/features/steps/add_a_survey.py
@@ -65,3 +65,19 @@ def click_cancel(context):
 def view_todo_list(context):
     browser.find_by_id('SURVEY_TODO_TAB')\
         .first.has_class('btn btn--secondary btn--border navigation-tabs__tab navigation-tabs__tab--active')
+
+
+@given('the user has entered a valid enrolment code for a survey they have already added')
+def enter_second_enrolment_code(context):
+    add_a_survey.go_to()
+    browser.driver.find_element_by_id('ENROLEMENT_CODE_FIELD').send_keys(context.second_iac)
+    browser.find_by_id('continue_button').click()
+
+
+@then('the user is notified they have already added the survey')
+def already_added_notification_presented_to_user(context):
+    assert browser.find_by_id('ALREADY_ADDED_NOTIF').text,\
+                'You have already added that survey'
+
+
+


### PR DESCRIPTION
# Motivation and Context
Tests the new functionality of displaying a message to the user that they have already added a survey instead of producing a 500 error.

# What has changed
<!--- What code changes has been made -->
User will be displayed an information panel on trying to add a survey they have already added.

# How to test?
Change what the assert is looking for to something not on the page and see if it fails.

# Links
The frontstage PR: https://github.com/ONSdigital/ras-frontstage/pull/421
https://trello.com/c/gfNFRVsR/569-569-add-validation-for-respondents-adding-another-survey-to-their-enrolment
