### PR TITLE
Fix tests until next year

### DIFF
--- a/acceptance_tests/features/set_ready_for_live.feature
+++ b/acceptance_tests/features/set_ready_for_live.feature
@@ -9,8 +9,8 @@ Feature: Set a collection exercise as ready for live
   @us028_s001
   @us028_s008
   Scenario: Once the user is happy with the contents of the collection exercise, they are able to set the collection exercise as 'Ready for Live'
-    Given "rsi" "201812" is in the ready for review state
-    And the user has checked the contents of "rsi" "201812" and it is all correct
+    Given "rsi" "201912" is in the ready for review state
+    And the user has checked the contents of "rsi" "201912" and it is all correct
     When they confirm that the collection exercise is ready to go live
     Then the user is informed that the collection exercise is setting as ready for live
     And when refreshing the page once processing has completed, the status is changed to Ready for Live


### PR DESCRIPTION
# Motivation and Context
Acceptance tests started failing today because the RSI December 2018 collection exercise went live at 00:00, and the tests expected to find the exercise in _ready_ for live state, which it would not, because it will automatically go live.

# What has changed
Changed collection exercise used to December 2019 - we are good for one whole year.

# How to test?
Run the acceptance tests. They should pass.

# Links
Trello: https://trello.com/c/Mv8D7thV/613-bug-fix-acceptance-tests-using-rsi-december-2018-collection-exercise-now-live