### PR TITLE
Convert remove-loaded-sample feature to standalone

### DIFF
--- a/acceptance_tests/features/remove_loaded_sample.feature
+++ b/acceptance_tests/features/remove_loaded_sample.feature
@@ -1,3 +1,5 @@
+@standalone
+@business
 Feature: Remove loaded sample
   As a collection Exercise Coordinator
   I need to be able to remove a loaded sample
@@ -7,6 +9,7 @@ Feature: Remove loaded sample
     Given the internal user is already signed in
 
   @us053-s01
+  @fixture.setup.data.with.internal.user.and.collection.exercise.to.scheduled.status
   Scenario: Remove a loaded sample
     Given user on the collection exercise details screen
     When they click on remove loaded sample
@@ -14,6 +17,7 @@ Feature: Remove loaded sample
     Then the loaded sample is removed
 
   @us053-s02
+  @fixture.setup.data.with.internal.user.and.collection.exercise.to.scheduled.status
   Scenario: Display successful sample removed message
     Given user has proceeded to remove loaded sample
     When they click on remove loaded sample
@@ -23,6 +27,7 @@ Feature: Remove loaded sample
     And the collection exercise status will reflect the sample has been removed
 
   @us053-s03
+  @fixture.setup.data.with.internal.user.and.collection.exercise.to.ready.for.live.status
   Scenario: Don't Display remove loaded sample from Ready For Live state
     Given user wants to remove a loaded sample from a collection exercise
     When the collection exercise has status is ready for live

--- a/acceptance_tests/features/steps/remove-loaded-sample.py
+++ b/acceptance_tests/features/steps/remove-loaded-sample.py
@@ -6,17 +6,15 @@ from acceptance_tests.features.pages import confirm_remove_sample, collection_ex
 
 @given('user on the collection exercise details screen')
 @given('user has proceeded to remove loaded sample')
-def check_user_is_on_collection_exercise_details_page(_):
-    collection_exercise_details.go_to('RSI', '201804')
-    assert "023 RSI 201804 | Surveys | Survey Data Collection" in browser.title
+def check_user_is_on_collection_exercise_details_page(context):
+    collection_exercise_details.go_to(context.short_name, context.period)
     collection_exercise_details.load_sample('resources/sample_files/business-survey-sample-date.csv')
     collection_exercise_details.get_sample_success_text()
 
 
 @given('user wants to remove a loaded sample from a collection exercise')
-def user_wants_to_remove_loaded_sample(_):
-    collection_exercise_details.go_to('QBS', '1809')
-    assert "139 QBS 1809 | Surveys | Survey Data Collection" in browser.title
+def user_wants_to_remove_loaded_sample(context):
+    collection_exercise_details.go_to(context.short_name, context.period)
 
 
 @when('they click on remove loaded sample')

--- a/acceptance_tests/features/steps/remove-loaded-sample.py
+++ b/acceptance_tests/features/steps/remove-loaded-sample.py
@@ -1,7 +1,6 @@
-from behave import given, when, then
+from behave import given, then, when
 
-from acceptance_tests import browser
-from acceptance_tests.features.pages import confirm_remove_sample, collection_exercise_details
+from acceptance_tests.features.pages import collection_exercise_details, confirm_remove_sample
 
 
 @given('user on the collection exercise details screen')


### PR DESCRIPTION
# Motivation and Context
Converts remove-loaded-sample to standalone. This feature is failing at the moment because of hardcoded dates being reached.

# What has changed
- Converted remove-loaded-sample.feature to standalone

# How to test?
Tests should all pass, remove-loaded-sample should be run in the parallel batch, not the sequential.

# Links
https://trello.com/c/ogTBNWPR/406-t406-acceptance-tests-convert-remove-loaded-samplefeature-to-standalone
