### PR TITLE
Remove sleep(10) between each scenario in parallel tests

### DIFF
--- a/run_in_parallel.py
+++ b/run_in_parallel.py
@@ -117,9 +117,6 @@ def _run_scenario(failure_queue: Queue, feature_scenario: str, scenario_index, t
     status = execution_code[code]
     logger.info(f'Finished {run_info} --> {status}')
 
-    # To give time for postgres connections to close before starting the next Scenario
-    time.sleep(10)
-
     return feature, scenario, status
 
 


### PR DESCRIPTION
# Motivation and Context
Speed up tests a small bit

# What has changed
Removed a sleep(10) that existed due to lack of connections (fixed)

# How to test?
Checkout branch and run 
make acceptance_parallel_tests

# Links
https://trello.com/c/pzuQ5VK1/403-t403-acceptance-tests-speed-up