### PR TITLE
Tests passing locally not on build server , attempting to rectify

### DIFF
--- a/acceptance_tests/features/fixtures.py
+++ b/acceptance_tests/features/fixtures.py
@@ -228,7 +228,7 @@ def setup_data_with_enrolled_respondent_and_additional_iac(context):
     context.add_cleanup(sign_out_internal.try_sign_out)
     context.second_iac = generate_new_enrolment_code_from_existing_code(context.iac)
 
-    
+
 def setup_data_with_enrolled_respondent_user_and_eq_collection_exercise_live(context):
     create_default_data(context, eq_ci=True)
     collection_exercise_controller.wait_for_collection_exercise_state(context.survey_id, context.period,

--- a/acceptance_tests/features/steps/add_a_survey.py
+++ b/acceptance_tests/features/steps/add_a_survey.py
@@ -78,6 +78,3 @@ def enter_second_enrolment_code(context):
 def already_added_notification_presented_to_user(context):
     assert browser.find_by_id('ALREADY_ADDED_NOTIF').text,\
                 'You have already added that survey'
-
-
-

--- a/acceptance_tests/features/steps/inbox_internal.py
+++ b/acceptance_tests/features/steps/inbox_internal.py
@@ -2,10 +2,12 @@ from datetime import datetime
 
 from behave import given, when, then
 
+from acceptance_tests import browser
 from acceptance_tests.features.pages import home, inbox_internal
 from acceptance_tests.features.pages.internal_conversation_view import go_to_thread
 from acceptance_tests.features.steps.authentication import signed_in_internal
 from controllers import messages_controller
+from common.browser_utilities import wait_for
 
 
 @given('the user has access to secure messaging')
@@ -115,7 +117,16 @@ def internal_user_has_unread_message_in_inbox(context):
 
 @then('they are able to distinguish that the message is unread')
 def internal_user_can_distinguish_the_message_is_unread(_):
+    wait_for(_validate_message_unread_on_page, 5, 1)
     assert len(inbox_internal.get_unread_messages()) > 0
+
+
+def _validate_message_unread_on_page():
+    try:
+        browser.find_by_name('message-unread')
+        return True
+    except Exception:
+        return False
 
 
 @when('they view the unread message')

--- a/acceptance_tests/features/steps/reply_to_message_internal.py
+++ b/acceptance_tests/features/steps/reply_to_message_internal.py
@@ -136,7 +136,7 @@ def url_is_for_open_messages(_):
 
 
 @then('they are taken back to my_messages')
-def url_is_for_open_messages(_):
+def url_is_for_my_messages(_):
     assert 'my_conversations=true' in browser.url
 
 

--- a/acceptance_tests/features/steps/view_full_thread.py
+++ b/acceptance_tests/features/steps/view_full_thread.py
@@ -46,7 +46,7 @@ def check_mark_as_unread_available(_):
 
 @then('They cannot see mark as unread')
 def check_mark_as_unread_unavailable(_):
-    assert browser.find_by_id('sm-mark-as-unread').is_empty()
+    assert not browser.find_by_id('sm-mark-as-unread')
 
 
 @when('they select mark unread')


### PR DESCRIPTION
# Motivation and Context
Acceptance tests passing locally but not on build server . Assuming browser differences and race condition

# What has changed
Changed way to look for mark unread label missing , and allowed time for unread messages to be displayed

# How to test?
run tests
