### PR TITLE
Skipping already added survey test

### DIFF
--- a/acceptance_tests/features/add_a_survey.feature
+++ b/acceptance_tests/features/add_a_survey.feature
@@ -10,11 +10,11 @@ Feature: Add a survey
 
 
   @fixture.setup.data.with.enrolled.respondent.and.additional.iac
+  @skip
   Scenario: User is trying to add a survey using a new iac code that they have previously added
     Given the user has entered a valid enrolment code for a survey they have already added
     When they continue and confirm that the organisation and survey that they are enrolling for is correct
     Then the user is notified they have already added the survey
-
 
   @fixture.setup.data.with.unenrolled.respondent.user
   @us334-addSurvey_s01


### PR DESCRIPTION
# Motivation and Context
We need to revert a change on ras-frontstage and leaving this test in will break the pipeline. For the time being, we're gonna skip the test.
# What has changed
- Added skip tag to `User is trying to add a survey using a new iac code that they have previously added`

# How to test?
- Run the acceptance tests with [the revert branch](https://github.com/ONSdigital/ras-frontstage/tree/revert-already-added-survey) and make sure all tests pass
