### PR TITLE
723 add asserts to wait

### DIFF
--- a/acceptance_tests/features/add_a_survey.feature
+++ b/acceptance_tests/features/add_a_survey.feature
@@ -8,7 +8,7 @@ Feature: Add a survey
   Background: User already logged in
     Given the respondent is signed into their account
 
-
+  @skip
   @fixture.setup.data.with.enrolled.respondent.and.additional.iac
   @skip
   Scenario: User is trying to add a survey using a new iac code that they have previously added

--- a/acceptance_tests/features/steps/inbox_internal.py
+++ b/acceptance_tests/features/steps/inbox_internal.py
@@ -116,7 +116,7 @@ def internal_user_has_unread_message_in_inbox(context):
 
 @then('they are able to distinguish that the message is unread')
 def internal_user_can_distinguish_the_message_is_unread(_):
-    wait_for(named_element_on_page, 8, 1, 'message-unread')
+    wait_for_element_by_name(name="message-unread", timeout=8, retry=1)
     assert len(inbox_internal.get_unread_messages()) > 0
 
 

--- a/acceptance_tests/features/steps/inbox_internal.py
+++ b/acceptance_tests/features/steps/inbox_internal.py
@@ -116,7 +116,7 @@ def internal_user_has_unread_message_in_inbox(context):
 
 @then('they are able to distinguish that the message is unread')
 def internal_user_can_distinguish_the_message_is_unread(_):
-    wait_for_element_by_name(name="message-unread", timeout=8, retry=1)
+    wait_for(named_element_on_page, 8, 1, 'message-unread')
     assert len(inbox_internal.get_unread_messages()) > 0
 
 

--- a/acceptance_tests/features/steps/reply_to_message_internal.py
+++ b/acceptance_tests/features/steps/reply_to_message_internal.py
@@ -10,7 +10,7 @@ from acceptance_tests.features.pages.reply_to_message_internal import get_curren
 from acceptance_tests.features.steps.authentication import signed_in_internal
 from controllers.messages_controller import create_message_external_to_internal, \
     create_and_close_message_internal_to_external
-from common.browser_utilities import wait_for_element_by_name
+from common.browser_utilities import wait_for_element_by_class_name
 
 
 @given('the internal user has received a message')
@@ -151,7 +151,7 @@ def internal_user_opens_first_message_on_page(context, page):
 def internal_user_taken_to_specific_page(context, page):
     inbox_internal.go_to_using_context(context)
     for page_num in range(1, int(page)):
-        wait_for_element_by_name(name='next', timeout=5, retry=1)
+        wait_for_element_by_class_name(name='next', timeout=5, retry=1)
         browser.driver.find_element_by_class_name('next').click()
 
 

--- a/acceptance_tests/features/view_full_thread_internal.feature
+++ b/acceptance_tests/features/view_full_thread_internal.feature
@@ -55,7 +55,7 @@ Feature: View conversation thread
     When The internal user is already signed in
       And the internal person views the message
       Then  They can see mark as unread
-     
+
 
   Scenario: Message sent from internal, respondent replies , user different to who sent original message can not mark as unread
     Given the internal user has received a message
@@ -71,8 +71,8 @@ Feature: View conversation thread
     When  the internal person views the message
       And the user selects back
     Then  the message is no longer marked as unread
-    
-    
+
+
   Scenario: Message sent from internal, respondent replies , user who sent original opens and selects back, message marked as read
     Given the internal user has received a message
       And  an internal user responds and respondent signs in

--- a/common/browser_utilities.py
+++ b/common/browser_utilities.py
@@ -13,7 +13,7 @@ def is_text_present_with_retry(text, retries=3, delay=1):
 
 
 def wait_for_element_by_name(name, timeout, retry):
-    """Waits for the named element to appear on the page
+    """Waits for the named element to appear on the page, asserts if not present after timeout
 
     Parameters:
         name (string): The name of the element to wait for
@@ -23,11 +23,35 @@ def wait_for_element_by_name(name, timeout, retry):
     Returns:
         boolean: True if element found else False
         """
-    return wait_for(_named_element_on_page, timeout, retry, name)
+
+    ret_val = wait_for(_named_element_on_page, timeout, retry, name)
+
+    assert ret_val
+
+    return ret_val
+
+
+def wait_for_element_by_class_name(name, timeout, retry):
+    """Waits for the named class to appear on the page, asserts if not present after timeout
+
+    Parameters:
+        name (string): The name of the element to wait for
+        timeout (int): Total amount of time in seconds to wait before returning a default of False
+        retry (int): Time in seconds after one attempt to check if element is on the screen.
+
+    Returns:
+        boolean: True if element found else False
+        """
+
+    ret_val = wait_for(_named_class_on_page, timeout, retry, name)
+
+    assert ret_val
+
+    return ret_val
 
 
 def wait_for_element_by_id(element_id, timeout, retry):
-    """Waits for the element with the specific id to appear on the page
+    """Waits for the element with the specific id to appear on the page, asserts if not present after timeout
 
     Parameters:
 
@@ -38,7 +62,10 @@ def wait_for_element_by_id(element_id, timeout, retry):
     Returns:
         boolean: True if element found else False
     """
-    return wait_for(_element_by_id_on_page, timeout, retry, element_id)
+    ret_val = wait_for(_element_by_id_on_page, timeout, retry, element_id)
+    assert ret_val
+
+    return ret_val
 
 
 def wait_for(fn, timeout, retry_after, *argv):
@@ -64,12 +91,18 @@ def wait_for(fn, timeout, retry_after, *argv):
         ret_val = fn(*argv) if argv else fn()
         if not ret_val:
             time.sleep(retry_after)
+
     return ret_val
 
 
 def _named_element_on_page(name):
     """Returns True if element of name:name is on current page, else False"""
     return True if browser.find_by_name(name) else False
+
+
+def _named_class_on_page(name):
+    """Returns True if class of name:name is on current page, else False"""
+    return True if browser.driver.find_element_by_class_name(name) else False
 
 
 def _element_by_id_on_page(element_id):


### PR DESCRIPTION
# Motivation and Context
Tests passing locally are failing in CI. With no indication why. We suspect that there may be timing issues. This will add an assert to each wait such that if after the wait period the element is still not present then an assert will be raised and visible in the output

# What has changed
Added assert to waits
Added wait for by class as the test that was using it passed locally and failed in CI , and used to use a by_class method

# How to test?
Run tests

