### PR TITLE
Added explicit logout for internal user , increased some wait times a…

### DIFF
--- a/acceptance_tests/features/pages/create_message_internal.py
+++ b/acceptance_tests/features/pages/create_message_internal.py
@@ -46,7 +46,7 @@ def click_cancel_button():
 
 
 def click_back_link():
-    wait_for_element_by_id(element_id='back-link', timeout=5, retry=1)
+    wait_for_element_by_id(element_id='back-link', timeout=15, retry=1)
     browser.find_by_id('back-link').click()
 
 

--- a/acceptance_tests/features/pages/internal_conversation_view.py
+++ b/acceptance_tests/features/pages/internal_conversation_view.py
@@ -8,7 +8,7 @@ def go_to():
 
 
 def go_to_thread():
-    wait_for_element_by_id(element_id='message-link-1', timeout=8, retry=1)
+    wait_for_element_by_id(element_id='message-link-1', timeout=20, retry=1)
     thread_subject = browser.find_by_id('message-link-1')
     thread_subject.click()
 

--- a/acceptance_tests/features/steps/add_a_survey.py
+++ b/acceptance_tests/features/steps/add_a_survey.py
@@ -2,6 +2,7 @@ from behave import given, when, then
 
 from acceptance_tests import browser
 from acceptance_tests.features.pages import surveys_todo, add_a_survey
+from common.browser_utilities import wait_for_element_by_id
 
 
 @when('the respondent views the survey list todo page')
@@ -53,7 +54,8 @@ def confirm_organisation_and_continue(context):
 
 @then('the new survey is to be listed in My Surveys and confirmation is presented to the user')
 def confirmation_presented_for_new_survey(context):
-    browser.find_by_id('NEW_SURVEY_NOTIF')
+    wait_for_element_by_id('NEW_SURVEY_NOTIF', timeout=20, retry=1)
+    assert browser.find_by_id('NEW_SURVEY_NOTIF')
 
 
 @when('they navigate to the confirm organisation page and click cancel')

--- a/acceptance_tests/features/steps/create-mandatory-ce-events.py
+++ b/acceptance_tests/features/steps/create-mandatory-ce-events.py
@@ -18,7 +18,7 @@ def check_no_mandatory_dates_for_ce(_, survey, period):
     survey = get_survey_by_short_name(survey)
     events = get_events_for_collection_exercise(survey['id'], period)
 
-    assert len(events) is 0
+    assert len(events) == 0
 
 
 @then('the user must be able to input the mandatory event dates into the CE "{period}" for a given "{survey}" survey')

--- a/acceptance_tests/features/steps/display_respondent_alongside_response_status.py
+++ b/acceptance_tests/features/steps/display_respondent_alongside_response_status.py
@@ -114,7 +114,7 @@ def no_longer_required_set_for_collex(_):
 @then('no Respondent name should be displayed in the Respondent field')
 def respondent_name_is_not_displayed(_):
     assert 'Respondent:' in browser.html
-    assert browser.find_by_id('completed-respondent')[0].value is ''
+    assert browser.find_by_id('completed-respondent')[0].value == ''
 
 
 @then('the Respondent details must be displayed in the Respondent field')

--- a/acceptance_tests/features/steps/inbox_internal.py
+++ b/acceptance_tests/features/steps/inbox_internal.py
@@ -116,7 +116,7 @@ def internal_user_has_unread_message_in_inbox(context):
 
 @then('they are able to distinguish that the message is unread')
 def internal_user_can_distinguish_the_message_is_unread(_):
-    wait_for_element_by_name(name="message-unread", timeout=8, retry=1)
+    wait_for_element_by_name(name="message-unread", timeout=20, retry=1)
     assert len(inbox_internal.get_unread_messages()) > 0
 
 

--- a/acceptance_tests/features/steps/sign_out_internal.py
+++ b/acceptance_tests/features/steps/sign_out_internal.py
@@ -1,4 +1,4 @@
-from behave import then, when
+from behave import given, then, when
 
 from acceptance_tests.features.pages import sign_out_internal
 
@@ -8,6 +8,7 @@ def view_home_page(_):
     sign_out_internal.signed_out_successfully_message()
 
 
+@given('they click the sign out link')
 @when('they click the sign out link')
 @then('the internal user signs out')
 def sign_out(_):

--- a/acceptance_tests/features/view_full_thread_internal.feature
+++ b/acceptance_tests/features/view_full_thread_internal.feature
@@ -59,7 +59,9 @@ Feature: View conversation thread
 
   Scenario: Message sent from internal, respondent replies , user different to who sent original message can not mark as unread
     Given the internal user has received a message
-      And  an internal user responds and respondent signs in
+      And an internal user responds
+      And they click the sign out link
+      And the respondent is signed into their account
       And the respondent navigates to their inbox
       And the respondent replies to first conversation
     When an alternate internal user signs in
@@ -85,7 +87,9 @@ Feature: View conversation thread
 
   Scenario: Message sent from internal, respondent replies , user different to who sent original opens and selects back, message not marked as read
     Given the internal user has received a message
-      And  an internal user responds and respondent signs in
+      And an internal user responds
+      And they click the sign out link
+      And the respondent is signed into their account
       And the respondent navigates to their inbox
       And the respondent replies to first conversation
     When an alternate internal user signs in
@@ -113,7 +117,9 @@ Feature: View conversation thread
 
   Scenario: Respondent sends to specific internal user , Another internal user should not see it in my messages
     Given the internal user has received a message
-      And  an internal user responds and respondent signs in
+      And an internal user responds
+      And they click the sign out link
+      And the respondent is signed into their account
       And the respondent navigates to their inbox
       And the respondent replies to first conversation
     When an alternate internal user signs in
@@ -122,7 +128,9 @@ Feature: View conversation thread
 
   Scenario: Respondent sends to specific internal user , Another internal user should see it in open messages
     Given the internal user has received a message
-      And  an internal user responds and respondent signs in
+      And an internal user responds
+      And they click the sign out link
+      And the respondent is signed into their account
       And the respondent navigates to their inbox
       And the respondent replies to first conversation
     When an alternate internal user signs in

--- a/common/browser_utilities.py
+++ b/common/browser_utilities.py
@@ -12,7 +12,7 @@ def is_text_present_with_retry(text, retries=3, delay=1):
     return False
 
 
-def wait_for_element_by_name(name, timeout, retry):
+def wait_for_element_by_name(name, timeout=10, retry=1):
     """Waits for the named element to appear on the page, asserts if not present after timeout
 
     Parameters:
@@ -31,7 +31,7 @@ def wait_for_element_by_name(name, timeout, retry):
     return ret_val
 
 
-def wait_for_element_by_class_name(name, timeout, retry):
+def wait_for_element_by_class_name(name, timeout=10, retry=1):
     """Waits for the named class to appear on the page, asserts if not present after timeout
 
     Parameters:
@@ -50,7 +50,7 @@ def wait_for_element_by_class_name(name, timeout, retry):
     return ret_val
 
 
-def wait_for_element_by_id(element_id, timeout, retry):
+def wait_for_element_by_id(element_id, timeout=10, retry=1):
     """Waits for the element with the specific id to appear on the page, asserts if not present after timeout
 
     Parameters:


### PR DESCRIPTION
Explicitly added logout to internal user  also added defaults to timeout calls

# Motivation and Context
Tests passing locally are failing consistently in ci. Even repeating the same setup locally does not repeat the issue. This will explicitly logout the internal user which may be an issue due to different cookie handling locally 

# What has changed
Modified features to explicitly sign out internal user prior to logging in as alternate internal user
Increased a few wait time outs ( still polls each second so no increase in test time anticipated) 
Added defaults to wait times so that they are more succinct to use

# How to test?
Run tests

# Links
https://trello.com/c/8eG7C9Vg
