### PR TITLE
732 fix impotent then clauses

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ install:
 script:
   - pipenv check --style . --max-line-length 120
   - make style_tests start_services
-  - travis_wait 15 make wait_for_services
+  - travis_wait 18 make wait_for_services
   - make system_tests acceptance_tests stop_services
 
 after_failure:

--- a/acceptance_tests/__init__.py
+++ b/acceptance_tests/__init__.py
@@ -25,7 +25,6 @@ def create_browser():
     if os.getenv('HEADLESS', 'True') == 'True':
         chromedriver_binary.add_chromedriver_to_path()
         chrome_options = webdriver.ChromeOptions()
-        chrome_options.headless = bool(strtobool(os.getenv('HEADLESS', 'True')))
         chrome_options.add_argument("--no-sandbox")
         return Browser('chrome', headless=True, options=chrome_options)
     else:

--- a/acceptance_tests/__init__.py
+++ b/acceptance_tests/__init__.py
@@ -3,7 +3,6 @@ import os
 
 from retrying import retry
 from selenium import webdriver
-import chromedriver_binary
 from splinter import Browser
 from structlog import configure
 from structlog.stdlib import LoggerFactory

--- a/acceptance_tests/__init__.py
+++ b/acceptance_tests/__init__.py
@@ -1,7 +1,6 @@
 import logging
 import os
 
-from distutils.util import strtobool
 from retrying import retry
 from selenium import webdriver
 import chromedriver_binary

--- a/acceptance_tests/__init__.py
+++ b/acceptance_tests/__init__.py
@@ -1,8 +1,10 @@
 import logging
 import os
 
+from distutils.util import strtobool
 from retrying import retry
 from selenium import webdriver
+import chromedriver_binary
 from splinter import Browser
 from structlog import configure
 from structlog.stdlib import LoggerFactory
@@ -19,8 +21,11 @@ def web_driver_connection_error(e):
 
 @retry(retry_on_exception=web_driver_connection_error, wait_fixed=1000, stop_max_attempt_number=30)
 def create_browser():
+
     if os.getenv('HEADLESS', 'True') == 'True':
+        chromedriver_binary.add_chromedriver_to_path()
         chrome_options = webdriver.ChromeOptions()
+        chrome_options.headless = bool(strtobool(os.getenv('HEADLESS', 'True')))
         chrome_options.add_argument("--no-sandbox")
         return Browser('chrome', headless=True, options=chrome_options)
     else:

--- a/acceptance_tests/features/add_a_survey.feature
+++ b/acceptance_tests/features/add_a_survey.feature
@@ -28,7 +28,7 @@ Feature: Add a survey
     When they add a new survey
     Then they are able to enter an enrolment code
 
-  @fixture.setup.data.with.unenrolled.respondent.user
+  @fixture.setup.data.with.unenrolled.respondent.user.and.new.iac
   @us334-addSurvey_s03
   Scenario: View survey & organisation that they are enrolling for
     Given selects to add a new survey

--- a/acceptance_tests/features/add_a_survey.feature
+++ b/acceptance_tests/features/add_a_survey.feature
@@ -10,7 +10,6 @@ Feature: Add a survey
 
   @skip
   @fixture.setup.data.with.enrolled.respondent.and.additional.iac
-  @skip
   Scenario: User is trying to add a survey using a new iac code that they have previously added
     Given the user has entered a valid enrolment code for a survey they have already added
     When they continue and confirm that the organisation and survey that they are enrolling for is correct

--- a/acceptance_tests/features/environment.py
+++ b/acceptance_tests/features/environment.py
@@ -17,6 +17,7 @@ from acceptance_tests.features.fixtures import setup_data_survey_with_internal_u
     setup_data_with_internal_user_and_social_collection_exercise_to_closed_status, \
     setup_data_with_respondent_user_data_and_new_iac, setup_data_with_unenrolled_respondent_user, \
     setup_data_with_unenrolled_respondent_user_and_internal_user, \
+    setup_data_with_unenrolled_respondent_user_and_new_iac, \
     setup_data_with_unenrolled_respondent_user_and_new_iac_and_collection_exercise_to_live, \
     setup_data_with_unverified_respondent, setup_sequential_data_for_test, setup_survey_metadata_with_internal_user, \
     setup_with_internal_user, setup_data_with_internal_user_and_collection_exercise_to_scheduled_status, \
@@ -69,6 +70,8 @@ fixture_scenario_registry = {
         setup_data_with_internal_user_and_social_collection_exercise_to_closed_status,
     'fixture.setup.data.with.internal.user.and.collection.exercise.to.ready.for.review.status':
         setup_data_with_internal_user_and_collection_exercise_to_ready_for_review_status,
+    'fixture.setup.data.with.unenrolled.respondent.user.and.new.iac':
+        setup_data_with_unenrolled_respondent_user_and_new_iac,
     'fixture.setup.data.with.unenrolled.respondent.user.and.new.iac.and.collection.exercise.to.live':
         setup_data_with_unenrolled_respondent_user_and_new_iac_and_collection_exercise_to_live,
     'fixture.setup.data.with.enrolled.respondent.user.and.internal.user.and.new.iac.and.collection.exercise.to.live':

--- a/acceptance_tests/features/fixtures.py
+++ b/acceptance_tests/features/fixtures.py
@@ -174,11 +174,17 @@ def _setup_data_with_internal_user_and_collection_exercise_to_specific_status(co
 def setup_data_with_unenrolled_respondent_user_and_new_iac_and_collection_exercise_to_live(context):
     """ Creates default data, an unenrolled Respondent, generates a new unused iac
     and waits until collection exercise state = live """
+    setup_data_with_unenrolled_respondent_user_and_new_iac(context)
+    collection_exercise_controller.wait_for_collection_exercise_state(context.survey_id, context.period,
+                                                                      expected_state=COLLECTION_EXERCISE_LIVE)
+
+
+@fixture
+def setup_data_with_unenrolled_respondent_user_and_new_iac(context):
+    """ Creates default data, an unenrolled Respondent, generates a new unused iac"""
     create_default_data(context)
     create_unenrolled_respondent(context)
     create_new_iac(context)
-    collection_exercise_controller.wait_for_collection_exercise_state(context.survey_id, context.period,
-                                                                      expected_state=COLLECTION_EXERCISE_LIVE)
 
 
 @fixture

--- a/acceptance_tests/features/pages/sign_in_internal.py
+++ b/acceptance_tests/features/pages/sign_in_internal.py
@@ -41,5 +41,5 @@ def check_password_required():
     browser.find_link_by_text('Please enter a password')
 
 
-def check_authentication_error_message():
-    browser.find_by_id('try-again-link')
+def authentication_retry_link():
+    return browser.find_by_id('try-again-link')

--- a/acceptance_tests/features/sign_in_internal.feature
+++ b/acceptance_tests/features/sign_in_internal.feature
@@ -9,34 +9,43 @@ Feature: Internal user signs in
   Scenario: User signs in correctly
     Given the user has an active account and is assigned a username and password
     When they enter the correct username and password
+    And they click the sign in button
     Then the user is directed to their home page
 
   Scenario: User attempts sign in with incorrect username and receives authentication error
     Given the user has an active account and is assigned a username and password
     When they enter an incorrect username and correct password
+    And they click the sign in button
     Then the user is notified that an authentication error has occurred
 
   Scenario: User attempts sign in with incorrect password and receives authentication error
     Given the user has an active account and is assigned a username and password
     When they enter a correct username and incorrect password
+    And they click the sign in button
     Then the user is notified that an authentication error has occurred
 
   Scenario: User attempts sign in and receives authentication error
     Given the user has an active account and is assigned a username and password
     When they enter an incorrect username and password
+    And they click the sign in button
     Then the user is notified that an authentication error has occurred
 
+  @skip
   Scenario: User attempts sign in and is notified that they are required to enter a password
     Given the user has an active account and is assigned a username and password
     When they enter a correct username and no password
+    And they click the sign in button
     Then the user is notified that a password is required
 
+  @skip
   Scenario: User attempts sign in and is notified that they are required to enter a username
     Given the user has an active account and is assigned a username and password
     When they enter no username and a correct password
+    And they click the sign in button
     Then the user is notified that a username is required
 
+  @skip
   Scenario: User attempts sign in and is notified that they are required to enter a username and password
     Given the user has an active account and is assigned a username and password
-    When they enter no username and no password
+    When they click the sign in button
     Then the user is notified that a username and password is required

--- a/acceptance_tests/features/steps/add_a_survey.py
+++ b/acceptance_tests/features/steps/add_a_survey.py
@@ -20,7 +20,7 @@ def add_a_new_survey(context):
 
 @then('they are able to enter an enrolment code')
 def enter_enrolment_code(context):
-    browser.find_by_id('ENROLMENT_CODE_FIELD')
+    assert browser.find_by_id('ENROLEMENT_CODE_FIELD')
 
 
 @given('the user has entered a valid enrolment code')
@@ -33,7 +33,7 @@ def enter_valid_enrolment_code(context):
 
 @then('they are to be presented with the survey and organisation that they are enrolling for')
 def view_confirmation_page(context):
-    browser.find_by_id('confirm-org-title')
+    assert browser.find_by_id('confirm-org-title')
 
 
 @when('they enter an invalid enrolment code')
@@ -44,7 +44,7 @@ def enter_invalid_enrolment_code(context):
 
 @then('they are to be notified')
 def invalid_enrolment_code_notification(context):
-    browser.find_by_id('error_notification')
+    assert browser.find_by_id('error_notification')
 
 
 @when('they continue and confirm that the organisation and survey that they are enrolling for is correct')

--- a/acceptance_tests/features/steps/display_trading_as_external.py
+++ b/acceptance_tests/features/steps/display_trading_as_external.py
@@ -61,7 +61,7 @@ def trading_as_field_does_not_appear(_):
         'Found "trading as" for a business that does not have a trading as name in respondent todo page'
 
 
-def _get_last_QBS_collection_exercise_id():
+def _get_last_qbs_collection_exercise_id():
     return get_collection_exercise('02b9c366-7397-42f7-942a-76dc5876d86d', '1809')['id']
 
 

--- a/acceptance_tests/features/steps/sign_in_internal.py
+++ b/acceptance_tests/features/steps/sign_in_internal.py
@@ -30,44 +30,38 @@ def try_sign_out():
 def sign_in_correct_username_and_password(context):
     sign_in_internal.enter_correct_username(context.internal_user_name)
     sign_in_internal.enter_correct_password()
-    sign_in_internal.click_internal_sign_in_button()
 
 
 @when('they enter an incorrect username and correct password')
 def sign_in_incorrect_username_and_correct_password(_):
     sign_in_internal.enter_incorrect_username()
     sign_in_internal.enter_correct_password()
-    sign_in_internal.click_internal_sign_in_button()
 
 
 @when('they enter a correct username and incorrect password')
 def sign_in_correct_username_and_incorrect_password(context):
     sign_in_internal.enter_correct_username(context.internal_user_name)
     sign_in_internal.enter_incorrect_password()
-    sign_in_internal.click_internal_sign_in_button()
 
 
 @when('they enter an incorrect username and password')
 def sign_in_incorrect_username_and_password(_):
     sign_in_internal.enter_incorrect_username()
     sign_in_internal.enter_incorrect_password()
-    sign_in_internal.click_internal_sign_in_button()
 
 
 @when('they enter a correct username and no password')
 def sign_in_correct_username_and_no_password(context):
     sign_in_internal.enter_correct_username(context.internal_user_name)
-    sign_in_internal.click_internal_sign_in_button()
 
 
 @when('they enter no username and a correct password')
 def sign_in_no_username_and_correct_password(_):
     sign_in_internal.enter_correct_password()
-    sign_in_internal.click_internal_sign_in_button()
 
 
-@when('they enter no username and no password')
-def sign_in_no_username_and_no_password(_):
+@when('they click the sign in button')
+def sign_in_click_sign_in_button(_):
     sign_in_internal.click_internal_sign_in_button()
 
 
@@ -94,4 +88,4 @@ def sign_in_username_and_password_required(_):
 
 @then('the user is notified that an authentication error has occurred')
 def authentication_error_occurred(_):
-    assert sign_in_internal.check_authentication_error_message()
+    assert sign_in_internal.authentication_retry_link()

--- a/acceptance_tests/features/steps/sign_in_internal.py
+++ b/acceptance_tests/features/steps/sign_in_internal.py
@@ -78,20 +78,20 @@ def sign_in_directed_to_home_page(_):
 
 @then('the user is notified that a username is required')
 def sign_in_username_required(_):
-    sign_in_internal.check_username_required()
+    assert sign_in_internal.check_username_required()
 
 
 @then('The user is notified that a password is required')
 def sign_in_password_required(_):
-    sign_in_internal.check_password_required()
+    assert sign_in_internal.check_password_required()
 
 
 @then('the user is notified that a username and password is required')
 def sign_in_username_and_password_required(_):
-    sign_in_internal.check_username_required()
-    sign_in_internal.check_password_required()
+    assert sign_in_internal.check_username_required()
+    assert sign_in_internal.check_password_required()
 
 
 @then('the user is notified that an authentication error has occurred')
 def authentication_error_occurred(_):
-    sign_in_internal.check_authentication_error_message()
+    assert sign_in_internal.check_authentication_error_message()

--- a/acceptance_tests/features/steps/social_sign_in_internal.py
+++ b/acceptance_tests/features/steps/social_sign_in_internal.py
@@ -78,20 +78,20 @@ def sign_in_directed_to_home_page(_):
 
 @then('the user is notified that a username is required (social)')
 def sign_in_username_required(_):
-    social_sign_in_internal.check_username_required()
+    assert social_sign_in_internal.check_username_required()
 
 
 @then('The user is notified that a password is required (social)')
 def sign_in_password_required(_):
-    social_sign_in_internal.check_password_required()
+    assert social_sign_in_internal.check_password_required()
 
 
 @then('the user is notified that a username and password is required (social)')
 def sign_in_username_and_password_required(_):
-    social_sign_in_internal.check_username_required()
-    social_sign_in_internal.check_password_required()
+    assert social_sign_in_internal.check_username_required()
+    assert social_sign_in_internal.check_password_required()
 
 
 @then('the user is notified that an authentication error has occurred (social)')
 def authentication_error_occurred(_):
-    social_sign_in_internal.check_authentication_error_message()
+    assert social_sign_in_internal.check_authentication_error_message()


### PR DESCRIPTION
# Motivation and Context
Several acceptance tests did not have any actions in then clauses that could give rise to an exception. After adding asserts to these , some where failing. Most where fixed but a few around sign in seem to be a wider issue. I.e Flask validation messages not displaying as they are caught by html 'required' attribute which led to expected messages never being rendered

# What has changed
Added asserts and fixed failing tests

# How to test?
Run each test modified in a debugger. Place breakpoint at then clause and validate that assert is valid at that point

# Links
https://trello.com/c/PA09DqMB
