### PR TITLE
Fix example seft survey file extension in development

### DIFF
--- a/acceptance_tests/features/steps/view_collection_instrument.py
+++ b/acceptance_tests/features/steps/view_collection_instrument.py
@@ -11,4 +11,4 @@ def collection_instruments_loaded(_):
 @then('they are able to see the filename of all collection instruments that have been loaded')
 def should_see_loaded_ci(_):
     cis = collection_exercise_details.get_collection_instruments()
-    assert 'test_collection_instrument.xlxs' in cis[0]
+    assert 'test_collection_instrument.xlsx' in cis[0]

--- a/controllers/collection_instrument_controller.py
+++ b/controllers/collection_instrument_controller.py
@@ -14,7 +14,7 @@ def upload_seft_collection_instrument(collection_exercise_id, file_path, form_ty
     url = f'{Config.COLLECTION_INSTRUMENT_SERVICE}/' \
           f'collection-instrument-api/1.0.2/upload/{collection_exercise_id}'
     mimetype = 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
-    files = {"file": ('test_collection_instrument.xlxs', open(file_path, 'rb'), mimetype)}
+    files = {"file": ('test_collection_instrument.xlsx', open(file_path, 'rb'), mimetype)}
 
     params = dict()
     if form_type:


### PR DESCRIPTION
# Motivation and Context
In the development environment, if you downloaded the example seft survey, then tried to reupload it, you'd have to change the file extension before you could (as xlxs isn't a valid extension)

# What has changed
The name of the example seft survey has been updated to have the correct extension when it's being set up.  There was also one place where it was looking for this, so we've updated it to look for the new (correct) full file name

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
