### PR TITLE
Fixes for broken acceptance tests

### DIFF
--- a/acceptance_tests/features/re_send_verification.feature
+++ b/acceptance_tests/features/re_send_verification.feature
@@ -1,3 +1,4 @@
+@standalone
 Feature: internal users can re-send the verification email
   as an internal user
   I need to be able to re-send respondents verification emails

--- a/acceptance_tests/features/steps/set_ready_for_live.py
+++ b/acceptance_tests/features/steps/set_ready_for_live.py
@@ -78,7 +78,7 @@ def refresh_ready_for_live(_):
 @then('they are asked for confirmation before continuing')
 def check_confirmation(_):
     alert = collection_exercise_details.get_confirmation_alert()
-    assert alert.text == 'There\'s no going back...'
+    assert alert.text == "This action cannot be undone.  Press 'OK' to continue, or 'Cancel' to go back."
     alert.dismiss()
 
 

--- a/common/collection_exercise_utilities.py
+++ b/common/collection_exercise_utilities.py
@@ -3,6 +3,7 @@ from datetime import datetime, timedelta
 from logging import getLogger
 
 from dateutil import tz
+from dateutil.tz import tzlocal
 from structlog import wrap_logger
 
 import common.string_utilities
@@ -100,7 +101,7 @@ def generate_collection_exercise_dates_from_period(period):
     """Generates a collection exercise events base date from the period supplied."""
 
     now = datetime.now()
-    now = now.replace(tzinfo=tz.gettz('Europe/London')).astimezone(tz.gettz('UTC'))
+    now = now.replace(tzinfo=tzlocal()).astimezone(tz.gettz('UTC'))
     period_year = int(period[:4])
     period_month = int(period[-2:])
 


### PR DESCRIPTION
# Motivation and Context
The pipeline has been broken for a couple of weeks and when testing it in the pipeline, there's some tests failing because of recent changes gone into response-operations-ui. These changes should hopefully get the pipeline green again.
# What has changed
- Changed test to find new alert message.
- Use local timezone for collection exercise events replace .
- Changed `re_send_verification.feature` to be a standalone test because it creates its own data.

# How to test?
- Run the acceptance tests and all should pass
