### PR TITLE
Fixed survey enrolment test

### DIFF
--- a/acceptance_tests/features/steps/survey_enrolment.py
+++ b/acceptance_tests/features/steps/survey_enrolment.py
@@ -43,6 +43,7 @@ def complete_account_details(context):
     browser.driver.find_element_by_id('first_name').send_keys('FirstName')
     browser.driver.find_element_by_id('last_name').send_keys('LastName')
     browser.driver.find_element_by_id('email_address').send_keys(context.respondent_email)
+    browser.driver.find_element_by_id('email_address_confirm').send_keys(context.respondent_email)
     browser.driver.find_element_by_id('password').send_keys('A234567_')
     browser.driver.find_element_by_id('password_confirm').send_keys('A234567_')
     browser.driver.find_element_by_id('phone_number').send_keys('01172345678')


### PR DESCRIPTION
# Motivation and Context
Test on the acceptance tests is failing due to a recent change that went into frontstage, this pr adds in the confirm email address box to the test so it can add the email address to it.

# What has changed
- Now checks for email_address_confirm

# How to test?
- Run the test locally and it should pass