### PR TITLE
Adding reset databases fix to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,3 +89,21 @@ The tests may be failing because you have teared down postgres recently
 If you've got an old image hanging around it could cause failures. There are two things to try
 1. Firstly run `make pull` within tmp_ras_rm_docker_dev and then re-run `make test`
 2. Secondly if that doesn't work run `docker kill $(docker ps -qa) ; docker rm $(docker ps -qa) ; docker rmi $(docker images -qa)` to delete all images and then re-run `make test`
+#### Failing setup
+##### Resetting databases bug
+When running the acceptance tests, it may get stuck on `resetting databases`. This happens because a process gets into a deadlock and after a few minutes the `make` command should terminate. There is a way of terminating
+the process before it hits a timeout and quits.
+
+If you run an sql statement such as below. It should terminate the process in the deadlock and carry on running the acceptance tests. If it stops running
+the `make acceptance_tests` command, just run the `make` command again and it should work.
+``` sql
+SELECT pg_terminate_backend(pid)
+FROM pg_stat_activity
+where state = 'idle in transaction' AND query like '%actioncase%'	
+``` 
+
+Another way of terminating the deadlock is by going into pgadmin and terminating it there
+1. Go to `localhost:80` and log in using details specified in [ras-rm-docker-dev](https://github.com/ONSdigital/ras-rm-docker-dev#pgadmin-4)
+2. Click on the database and it should show you a dashboard displaying server activity
+3. You'll notice that a some of the processes are deadlocked on a single process (usually the lowest PID in Blocking PIDs column). Terminate that process and the acceptance
+tests will either resume or terminate. If they terminate, running it again should work. 

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ If you've got an old image hanging around it could cause failures. There are two
 When running the acceptance tests, it may get stuck on `resetting databases`. This happens because a process gets into a deadlock and after a few minutes the `make` command should terminate. There is a way of terminating
 the process before it hits a timeout and quits.
 
-If you run the sql statement below. It should terminate the process in the deadlock and carry on running the acceptance tests. If it stops running
+If you run the sql statement below, it should terminate the process in the deadlock and carry on running the acceptance tests. If it stops running
 the `make acceptance_tests` command, just run the `make` command again and it should work.
 ``` sql
 SELECT pg_terminate_backend(pid)

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ If you've got an old image hanging around it could cause failures. There are two
 When running the acceptance tests, it may get stuck on `resetting databases`. This happens because a process gets into a deadlock and after a few minutes the `make` command should terminate. There is a way of terminating
 the process before it hits a timeout and quits.
 
-If you run an sql statement such as below. It should terminate the process in the deadlock and carry on running the acceptance tests. If it stops running
+If you run the sql statement below. It should terminate the process in the deadlock and carry on running the acceptance tests. If it stops running
 the `make acceptance_tests` command, just run the `make` command again and it should work.
 ``` sql
 SELECT pg_terminate_backend(pid)

--- a/run_in_parallel.py
+++ b/run_in_parallel.py
@@ -32,7 +32,7 @@ DEFAULT_LOG_LEVEL = 'INFO'
 DEFAULT_BEHAVE_FORMAT = 'progress2'
 DEFAULT_TAGS = '@standalone'
 DEFAULT_FEATURE_DIRECTORY = 'acceptance_tests/features'
-DEFAULT_THREADS = 6  # Higher than 6 causes collex (and possibly other services) to fail intermittently
+DEFAULT_THREADS = 13  # Higher than 6 causes collex (and possibly other services) to fail intermittently
 DEFAULT_SCENARIO_TIMEOUT = 300
 DEFAULT_NO_PARALLEL_STOP = 'store_true'
 

--- a/run_in_parallel.py
+++ b/run_in_parallel.py
@@ -32,7 +32,7 @@ DEFAULT_LOG_LEVEL = 'INFO'
 DEFAULT_BEHAVE_FORMAT = 'progress2'
 DEFAULT_TAGS = '@standalone'
 DEFAULT_FEATURE_DIRECTORY = 'acceptance_tests/features'
-DEFAULT_THREADS = 13  # Higher than 6 causes collex (and possibly other services) to fail intermittently
+DEFAULT_THREADS = 6  # Higher than 6 causes collex (and possibly other services) to fail intermittently
 DEFAULT_SCENARIO_TIMEOUT = 300
 DEFAULT_NO_PARALLEL_STOP = 'store_true'
 


### PR DESCRIPTION
# Motivation and Context
Theres a bug when running the acceptance tests where it gets stuck when running the reset databases script. This will normally terminate after a few minutes but you waste so much time just waiting for the command to timeout. This PR shows you how to terminate the deadlocked process so you can save a bit of time while running the acceptance tests.

# What has changed
- Added section in the README about the reset database bug

# How to test?
- When running the acceptance tests, you could run the sql command to make sure it works as expected.