### PR TITLE
Removed test that temporarily doesn't apply due to bug fix

### DIFF
--- a/acceptance_tests/features/steps/edit_collection_exercise_details.py
+++ b/acceptance_tests/features/steps/edit_collection_exercise_details.py
@@ -21,7 +21,8 @@ def edit_collection_exercise_details(context):
     context.expected_user_description = period.strftime("%d %B %Y")
 
     edit_collection_exercise_details_form.edit_period(context.expected_period)
-    edit_collection_exercise_details_form.edit_user_description(context.expected_user_description)
+    # Line below _temporarily removed_ until temporary ticket to remove editing is reversed.
+    # edit_collection_exercise_details_form.edit_user_description(context.expected_user_description)
     edit_collection_exercise_details_form.click_save()
 
 


### PR DESCRIPTION
# Motivation and Context
Removed a test for a feature that isn't there anymore

# What has changed
Edit collection exercise no longer checks for ability to edit user description, as this box has been removed.

Have commented the code out as it will need reintroducing when bug is properly addressed.

# How to test?
Run tests and ensure they don't fail on collection exercise editing. There are other fails happen intermittently, that are unrelated.

