### PR TITLE
new-respondent-conversations

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -71,10 +71,10 @@
         },
         "certifi": {
             "hashes": [
-                "sha256:046832c04d4e752f37383b628bc601a7ea7211496b4638f6514d0e5b9acc4939",
-                "sha256:945e3ba63a0b9f577b1395204e13c3a231f9bc0223888be653286534e5873695"
+                "sha256:e4f3620cfea4f83eedc95b24abd9cd56f3c4b146dd0177e83a21b4eb49e21e50",
+                "sha256:fd7c7c74727ddcf00e9acd26bba8da604ffec95bf1c2144e67aff7a8b50e6cef"
             ],
-            "version": "==2019.6.16"
+            "version": "==2019.9.11"
         },
         "cffi": {
             "hashes": [
@@ -118,10 +118,10 @@
         },
         "chromedriver-binary": {
             "hashes": [
-                "sha256:2e3dcd98c74d3b586814e857f1c6221f17d23d20b39babc8b71ba67ab2647dd0"
+                "sha256:5f3478c1ad4b6f618fcead2a7bd7b35f7bbfba6b637a3dffe646aad6af4b3b6a"
             ],
             "index": "pypi",
-            "version": "==76.0.3809.68.0"
+            "version": "==76.0.3809.126.0"
         },
         "cryptography": {
             "hashes": [
@@ -178,9 +178,9 @@
         },
         "parse": {
             "hashes": [
-                "sha256:1b68657434d371e5156048ca4a0c5aea5afc6ca59a2fea4dd1a575354f617142"
+                "sha256:a5fca7000c6588d77bc65c28f3f21bfce03b5e44daa8f9f07c17fe364990d717"
             ],
-            "version": "==1.12.0"
+            "version": "==1.12.1"
         },
         "parse-type": {
             "hashes": [
@@ -324,10 +324,10 @@
         },
         "sqlalchemy": {
             "hashes": [
-                "sha256:217e7fc52199a05851eee9b6a0883190743c4fb9c8ac4313ccfceaffd852b0ff"
+                "sha256:2f8ff566a4d3a92246d367f2e9cd6ed3edeef670dcd6dda6dfdc9efed88bcd80"
             ],
             "index": "pypi",
-            "version": "==1.3.6"
+            "version": "==1.3.8"
         },
         "structlog": {
             "hashes": [

--- a/acceptance_tests/__init__.py
+++ b/acceptance_tests/__init__.py
@@ -27,7 +27,7 @@ def create_browser():
         chromedriver_binary.add_chromedriver_to_path()
         chrome_options = webdriver.ChromeOptions()
         chrome_options.add_argument("--no-sandbox")
-        return Browser(driver_type, headless=driver_type, options=chrome_options)
+        return Browser(driver_type, headless=headless, options=chrome_options)
 
     return Browser(driver_type, headless=headless)
 

--- a/acceptance_tests/features/inbox_internal.feature
+++ b/acceptance_tests/features/inbox_internal.feature
@@ -95,3 +95,9 @@ Feature: Internal inbox
     Given the user has access to secure messaging
     When they navigate to the inbox messages
     Then they can see the closed tab
+
+  @fixture.setup.data.with.enrolled.respondent.user.and.internal.user.and.new.iac.and.collection.exercise.to.live
+  Scenario: Internal User views new conversations
+    Given both the internal and external users have started '3' conversations
+    When they navigate to initial conversations
+    Then they are able to view '3' messages

--- a/acceptance_tests/features/pages/inbox_internal.py
+++ b/acceptance_tests/features/pages/inbox_internal.py
@@ -1,4 +1,5 @@
 from acceptance_tests import browser
+from common.browser_utilities import wait_for_url_matches
 from config import Config
 
 
@@ -12,19 +13,33 @@ def go_to_closed():
 
 # todo delete above 2 methods when all tests use 2 below
 def go_to_using_context(context):
-    browser.visit(f"{Config.RESPONSE_OPERATIONS_UI}/messages/{context.short_name}")
+    target_url = f"{Config.RESPONSE_OPERATIONS_UI}/messages/{context.short_name}"
+    browser.visit(target_url)
+    wait_for_url_matches(target_url, timeout=3, retry=0.5, post_change_delay=0.1)
 
 
 def go_to_closed_using_context(context):
-    browser.visit(f"{Config.RESPONSE_OPERATIONS_UI}/messages/{context.short_name}?is_closed=true")
+    target_url = f"{Config.RESPONSE_OPERATIONS_UI}/messages/{context.short_name}?is_closed=true"
+    browser.visit(target_url)
+    wait_for_url_matches(target_url, timeout=3, retry=0.5, post_change_delay=0.1)
 
 
 def go_to_my_conversations_using_context(context):
-    browser.visit(f"{Config.RESPONSE_OPERATIONS_UI}/messages/{context.short_name}?my_conversations=true")
+    target_url = f"{Config.RESPONSE_OPERATIONS_UI}/messages/{context.short_name}?my_conversations=true"
+    browser.visit(target_url)
+    wait_for_url_matches(target_url, timeout=3, retry=0.5, post_change_delay=0.1)
+
+
+def go_to_initial_conversations_using_context(context):
+    target_url = f"{Config.RESPONSE_OPERATIONS_UI}/messages/{context.short_name}?new_respondent_conversations=true"
+    browser.visit(target_url)
+    wait_for_url_matches(target_url, timeout=3, retry=0.5, post_change_delay=0.1)
 
 
 def go_to_select_survey():
-    browser.visit(f"{Config.RESPONSE_OPERATIONS_UI}/messages/select-survey")
+    target_url = f"{Config.RESPONSE_OPERATIONS_UI}/messages/select-survey"
+    browser.visit(target_url)
+    wait_for_url_matches(target_url, timeout=3, retry=0.5, post_change_delay=0.1)
 
 
 def get_page_title():

--- a/acceptance_tests/features/steps/external_conversation.py
+++ b/acceptance_tests/features/steps/external_conversation.py
@@ -18,7 +18,7 @@ def external_user_has_two_conversations(context, conversation_count):
 
 @given("the external user has conversations in their list")
 def external_user_has_two_conversations(context):
-    _external_and_internal_have_multiple_conversations(conversation_count=1)
+    _external_and_internal_have_multiple_conversations(context, conversation_count=1)
 
 
 def _external_and_internal_have_multiple_conversations(context, conversation_count=1):

--- a/acceptance_tests/features/steps/external_conversation.py
+++ b/acceptance_tests/features/steps/external_conversation.py
@@ -11,10 +11,20 @@ def messages_tab_is_present(_):
     assert browser.find_by_id('SURVEY_MESSAGES_TAB')
 
 
-@given('the external user has conversations in their list')
+@given("both the internal and external users have started '{conversation_count}' conversations")
+def external_user_has_two_conversations(context, conversation_count):
+    _external_and_internal_have_multiple_conversations(context, int(conversation_count))
+
+
+@given("the external user has conversations in their list")
 def external_user_has_two_conversations(context):
-    external_conversation.send_message_from_external(context)
-    external_conversation.send_message_from_internal(context)
+    _external_and_internal_have_multiple_conversations(conversation_count=1)
+
+
+def _external_and_internal_have_multiple_conversations(context, conversation_count=1):
+    for x in range(0, conversation_count):
+        external_conversation.send_message_from_external(context)
+        external_conversation.send_message_from_internal(context)
 
 
 @given('the external user has no conversations to view')

--- a/acceptance_tests/features/steps/inbox_internal.py
+++ b/acceptance_tests/features/steps/inbox_internal.py
@@ -66,6 +66,12 @@ def internal_user_views_my_messages(context):
     inbox_internal.go_to_my_conversations_using_context(context)
 
 
+@given('they navigate to initial conversations')
+@when('they navigate to initial conversations')
+def internal_user_views_initial_conversations(context):
+    inbox_internal.go_to_initial_conversations_using_context(context)
+
+
 @then('they are informed that there are no closed conversations')
 def informed_of_no_closed_conversations(_):
     assert inbox_internal.get_no_closed_conversations_text()

--- a/acceptance_tests/features/steps/view_and_reply_conversation_external.py
+++ b/acceptance_tests/features/steps/view_and_reply_conversation_external.py
@@ -17,7 +17,7 @@ from controllers.messages_controller import create_message_external_to_internal,
 
 
 @given('an external user has sent ONS a message')
-def external_user_has_sent_ONS_a_message(context):
+def external_user_has_sent_ons_a_message(context):
     create_message_external_to_internal(context, 'Message to ONS', 'Message body to ONS')
 
 


### PR DESCRIPTION
# Motivation and Context
new tab on response ops , that should only show new conversations  from respondents

# What has changed
New test added that checks the number of messages in the case of new messages from both respondent and internal

# How to test?
Run acceptance tests 

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
