### PR TITLE
validating correct tab when back via flash message

### DIFF
--- a/acceptance_tests/features/pages/collection_exercise_details.py
+++ b/acceptance_tests/features/pages/collection_exercise_details.py
@@ -5,7 +5,7 @@ from selenium.webdriver.support.ui import Select
 
 from acceptance_tests import browser
 from acceptance_tests.features.pages import collection_exercise
-from common.browser_utilities import is_text_present_with_retry, \
+from common.browser_utilities import is_text_present_with_retry, is_text_present_with_action, \
     wait_for_url_matches, wait_for_element_by_name, wait_for_element_by_id, wait_for_url_path_or_query_changed
 from config import Config
 
@@ -41,9 +41,8 @@ def load_sample(sample_file_path):
 
 
 def get_sample_success_text():
-    while not is_text_present_with_retry('Sample loaded'):
-        click_refresh_link_for_sample_upload()
-    return browser.find_by_id('sample-success').first.text
+    if is_text_present_with_action('Sample loaded', click_refresh_link_for_sample_upload, retries=3, delay=3):
+        return browser.find_by_id('sample-success').first.text
 
 
 def has_sample_preview():

--- a/acceptance_tests/features/pages/inbox_internal.py
+++ b/acceptance_tests/features/pages/inbox_internal.py
@@ -3,35 +3,18 @@ from common.browser_utilities import wait_for_url_matches
 from config import Config
 
 
-def go_to(context):
-    browser.visit(f"{Config.RESPONSE_OPERATIONS_UI}/messages/{context.short_name}")
+# def go_to(context):
+#     browser.visit(f"{Config.RESPONSE_OPERATIONS_UI}/messages/{context.short_name}")
 
 
-def go_to_closed():
-    browser.visit(f"{Config.RESPONSE_OPERATIONS_UI}/messages/Bricks?is_closed=true")
-
-
+# def go_to_closed():
+#     browser.visit(f"{Config.RESPONSE_OPERATIONS_UI}/messages/Bricks?conversation_tab=closed")
 # todo delete above 2 methods when all tests use 2 below
-def go_to_using_context(context):
-    target_url = f"{Config.RESPONSE_OPERATIONS_UI}/messages/{context.short_name}"
-    browser.visit(target_url)
-    wait_for_url_matches(target_url, timeout=3, retry=0.5, post_change_delay=0.1)
 
 
-def go_to_closed_using_context(context):
-    target_url = f"{Config.RESPONSE_OPERATIONS_UI}/messages/{context.short_name}?is_closed=true"
-    browser.visit(target_url)
-    wait_for_url_matches(target_url, timeout=3, retry=0.5, post_change_delay=0.1)
-
-
-def go_to_my_conversations_using_context(context):
-    target_url = f"{Config.RESPONSE_OPERATIONS_UI}/messages/{context.short_name}?my_conversations=true"
-    browser.visit(target_url)
-    wait_for_url_matches(target_url, timeout=3, retry=0.5, post_change_delay=0.1)
-
-
-def go_to_initial_conversations_using_context(context):
-    target_url = f"{Config.RESPONSE_OPERATIONS_UI}/messages/{context.short_name}?new_respondent_conversations=true"
+def go_to_using_context(context, conversation_tab='open'):
+    tab = conversation_tab.replace(' ', '+')
+    target_url = f"{Config.RESPONSE_OPERATIONS_UI}/messages/{context.short_name}?conversation_tab={tab}"
     browser.visit(target_url)
     wait_for_url_matches(target_url, timeout=3, retry=0.5, post_change_delay=0.1)
 

--- a/acceptance_tests/features/pages/inbox_internal.py
+++ b/acceptance_tests/features/pages/inbox_internal.py
@@ -3,15 +3,6 @@ from common.browser_utilities import wait_for_url_matches
 from config import Config
 
 
-# def go_to(context):
-#     browser.visit(f"{Config.RESPONSE_OPERATIONS_UI}/messages/{context.short_name}")
-
-
-# def go_to_closed():
-#     browser.visit(f"{Config.RESPONSE_OPERATIONS_UI}/messages/Bricks?conversation_tab=closed")
-# todo delete above 2 methods when all tests use 2 below
-
-
 def go_to_using_context(context, conversation_tab='open'):
     tab = conversation_tab.replace(' ', '+')
     target_url = f"{Config.RESPONSE_OPERATIONS_UI}/messages/{context.short_name}?conversation_tab={tab}"

--- a/acceptance_tests/features/pages/reply_to_message_internal.py
+++ b/acceptance_tests/features/pages/reply_to_message_internal.py
@@ -8,7 +8,7 @@ def get_current_url():
 
 
 def reply_to_first_message_in_message_box(context):
-    inbox_internal.go_to(context)
+    inbox_internal.go_to_using_context(context, 'open')
     go_to_thread()
     create_message_internal.enter_text_in_message_body('Body of reply from ONS internal user')
     create_message_internal.click_message_send_button()

--- a/acceptance_tests/features/reply_to_message_internal.feature
+++ b/acceptance_tests/features/reply_to_message_internal.feature
@@ -68,18 +68,3 @@ Feature: Reply to message internal
     When they view the message
     Then they are able to see the messages in the conversation in chronological order
 
-  @sm599_s01
-  Scenario: When closing a conversation the user should be returned to the same page
-    Given the user has got '30' messages in their inbox
-    And the internal user opens first message on page '2'
-    When they close the conversation
-    Then they are taken back to page '2'
-    And they receive confirmation that the conversation is closed
-
-  @sm599_s02
-  Scenario: When closing the only conversation on the final page the user should be returned to the new final page
-    Given the user has got '21' messages in their inbox
-    And the internal user opens first message on page '3'
-    When they close the conversation
-    Then they are taken back to page '2'
-    And they receive confirmation that the conversation is closed

--- a/acceptance_tests/features/steps/external_conversation.py
+++ b/acceptance_tests/features/steps/external_conversation.py
@@ -40,7 +40,7 @@ def external_user_sent_message_with_over_80_characters(context):
 @given('a closed conversation has been reopened')
 def close_and_reopen_a_conversation(context):
     create_and_close_message_internal_to_external(context, 'Message to ONS', 'Message body to ONS')
-    inbox_internal.go_to_closed_using_context(context)
+    inbox_internal.go_to_using_context(context, 'closed')
     internal_conversation_view.go_to_thread()
     create_message_internal.click_reopen_conversation_button()
 

--- a/acceptance_tests/features/steps/inbox_internal.py
+++ b/acceptance_tests/features/steps/inbox_internal.py
@@ -21,7 +21,7 @@ def populate_database_with_messages(context):
     body = "This is the body of the message"
     messages_controller.create_message_internal_to_external(context, subject, body)
 
-    inbox_internal.go_to_using_context(context)
+    inbox_internal.go_to_using_context(context, 'open')
 
 
 @given("the user has got '{number_of_messages}' messages in their inbox")
@@ -31,7 +31,7 @@ def populate_database_with_number_of_messages(context, number_of_messages):
         body = str(i) + ": This is the body of the message"
         messages_controller.create_message_internal_to_external(context, subject, body)
 
-    inbox_internal.go_to_using_context(context)
+    inbox_internal.go_to_using_context(context, 'open')
 
 
 @given('the user has no messages in their inbox')
@@ -42,7 +42,7 @@ def user_has_no_messages_in_inbox(_):
 @when('internal user navigate to the inbox messages')
 @when('they navigate to the inbox messages')
 def internal_user_views_messages(context):
-    inbox_internal.go_to_using_context(context)
+    inbox_internal.go_to_using_context(context, 'open')
 
 
 @then('they are informed that there are no messages')
@@ -57,19 +57,19 @@ def informed_of_no_my_messages(_):
 
 @when('they navigate to closed conversations')
 def internal_user_views_closed_messages(context):
-    inbox_internal.go_to_closed_using_context(context)
+    inbox_internal.go_to_using_context(context, 'closed')
 
 
 @given('they navigate to my messages')
 @when('they navigate to my messages')
 def internal_user_views_my_messages(context):
-    inbox_internal.go_to_my_conversations_using_context(context)
+    inbox_internal.go_to_using_context(context, 'my messages')
 
 
 @given('they navigate to initial conversations')
 @when('they navigate to initial conversations')
 def internal_user_views_initial_conversations(context):
-    inbox_internal.go_to_initial_conversations_using_context(context)
+    inbox_internal.go_to_using_context(context, 'initial')
 
 
 @then('they are informed that there are no closed conversations')

--- a/acceptance_tests/features/steps/reply_to_message_internal.py
+++ b/acceptance_tests/features/steps/reply_to_message_internal.py
@@ -39,16 +39,17 @@ def create_and_close_conversation(context):
 @when('they view the message')
 @when('the internal person views the message')
 def internal_user_can_view_open_message(context):
-    inbox_internal.go_to_using_context(context)
+    inbox_internal.go_to_using_context(context, 'open')
     go_to_thread()
 
 
 @when('they view the closed message')
 def internal_user_can_view_closed_message(context):
-    inbox_internal.go_to_closed_using_context(context)
+    inbox_internal.go_to_using_context(context, 'closed')
     go_to_thread()
 
 
+@given('they close the conversation')
 @when('they close the conversation')
 def close_a_conversation(_):
     create_message_internal.click_close_conversation_button()
@@ -83,20 +84,27 @@ def internal_user_receives_confirmation(_):
     assert 'Message sent' in create_message_internal.get_first_flashed_message()
 
 
+@given('they receive confirmation that the conversation is closed')
 @then('they receive confirmation that the conversation is closed')
 def internal_user_informed_that_conversation_is_closed(_):
     assert 'Conversation closed.' in create_message_internal.get_first_flashed_message()
 
 
+@when('they view the conversation via the flash message')
+def internal_user_view_conversation_via_flash_message(_):
+    create_message_internal.get_first_flashed_message()
+    browser.find_by_id("flashed-message-1").click()
+
+
 @then('the conversation appears in their closed list')
 def message_in_closed_list(context):
-    inbox_internal.go_to_closed_using_context(context)
+    inbox_internal.go_to_using_context(context, 'closed')
     assert len(inbox_internal.get_messages()) == 1
 
 
 @then('the conversation is not present in their closed list')
 def no_messages_in_closed_list(context):
-    inbox_internal.go_to_closed_using_context(context)
+    inbox_internal.go_to_using_context(context, 'closed')
     assert inbox_internal.get_no_closed_conversations_text()
 
 
@@ -107,13 +115,13 @@ def internal_user_informed_that_conversation_has_been_reopened(_):
 
 @then('the conversation is present in their open list')
 def conversation_in_open_list(context):
-    inbox_internal.go_to_using_context(context)
+    inbox_internal.go_to_using_context(context, 'open')
     assert len(inbox_internal.get_messages()) > 0
 
 
 @then('the conversation is present in their my_messages list')
 def conversation_in_my_messages_list(context):
-    inbox_internal.go_to_my_conversations_using_context(context)
+    inbox_internal.go_to_using_context(context, 'my messages')
     assert len(inbox_internal.get_messages()) > 0
 
 
@@ -132,24 +140,33 @@ def messages_in_chronological_order(_):
 
 @then('they are taken back to open messages')
 def url_is_for_open_messages(_):
-    assert 'my_conversations=false' in browser.url
+    assert 'conversation_tab=open' in browser.url
 
 
 @then('they are taken back to my_messages')
 def url_is_for_my_messages(_):
-    assert 'my_conversations=true' in browser.url
+    assert 'conversation_tab=my+messages' in browser.url
 
 
 @given("the internal user opens first message on page '{page}'")
 def internal_user_opens_first_message_on_page(context, page):
-    internal_user_taken_to_specific_page(context, page)
+    internal_user_opens_first_message_on_tab_and_page(context, 'open', page)
 
+
+@given("the internal user opens first message in tab '{conversation_tab}' and page '{page}'")
+def internal_user_opens_first_message_on_tab_and_page(context, conversation_tab, page):
+    internal_user_taken_to_specific_tab_and_page(context, conversation_tab, page)
     go_to_thread()
 
 
 @given("the internal user goes to page '{page}'")
 def internal_user_taken_to_specific_page(context, page):
-    inbox_internal.go_to_using_context(context)
+    internal_user_taken_to_specific_tab_and_page(context, 'open', page)
+
+
+@given("the internal user goes to tab '{conversation_tab}' and page '{page}'")
+def internal_user_taken_to_specific_tab_and_page(context, conversation_tab, page):
+    inbox_internal.go_to_using_context(context, conversation_tab)
     for page_num in range(1, int(page)):
         wait_for_element_by_class_name(name='next', timeout=5, retry=1)
         browser.driver.find_element_by_class_name('next').click()

--- a/acceptance_tests/features/steps/set_ready_for_live.py
+++ b/acceptance_tests/features/steps/set_ready_for_live.py
@@ -64,7 +64,7 @@ def refresh_ready_for_live(_):
 @then('they are asked for confirmation before continuing')
 def check_confirmation(_):
     alert = collection_exercise_details.get_confirmation_alert()
-    assert alert.text == "This action cannot be undone.  Press 'OK' to continue, or 'Cancel' to go back."
+    assert alert.text == "This action cannot be undone.  Press OK to continue, or Cancel to go back."
     alert.dismiss()
 
 

--- a/acceptance_tests/features/view_full_thread_internal.feature
+++ b/acceptance_tests/features/view_full_thread_internal.feature
@@ -160,3 +160,13 @@ Feature: View conversation thread
     When they view the unread message
     And they select mark unread
     Then they are taken back to page '2'
+
+  Scenario: When closing a conversation and selecting view conversation in flash message, pressing back goes to correct tab
+    Given the user has got '3' messages in their inbox
+      And they navigate to my messages
+      And the internal user opens first message in tab 'my messages' and page '1'
+      And they close the conversation
+      And they receive confirmation that the conversation is closed
+    When they view the conversation via the flash message
+      And the user selects back
+    Then they are taken back to my_messages

--- a/common/browser_utilities.py
+++ b/common/browser_utilities.py
@@ -3,10 +3,26 @@ from datetime import datetime, timedelta
 from selenium.common.exceptions import NoSuchElementException    
 from logging import getLogger
 from structlog import wrap_logger
-from urllib.parse  import urlparse
+from urllib.parse import urlparse
 from acceptance_tests import browser
 
 logger = wrap_logger(getLogger(__name__))
+
+
+def is_text_present_with_action(text, action, retries=3, delay=1):
+    """Waits for text to be present, if not present after delay then perform an action
+         Parameters:
+         text: Text to look for
+         action: action function to call if not present after delay
+         retries: The maximum number of reloads that may be attempted
+         delay: The amount of time to check if the text is present.
+    Returns: True if text found else False"""
+
+    for attempt in range(retries):
+        if browser.is_text_present(text, wait_time=delay):
+            return True
+        action()
+    return False
 
 
 def is_text_present_with_retry(text, retries=3, delay=1):

--- a/common/collection_exercise_utilities.py
+++ b/common/collection_exercise_utilities.py
@@ -62,14 +62,21 @@ def execute_collection_exercise(survey_id, period, ci_type='SEFT'):
 
 def poll_database_for_iac(survey_id, period, social=False):
     logger.info('Waiting for collection exercise execution process to finish',
-                 survey_id=survey_id, period=period)
+                survey_id=survey_id, period=period)
     collection_exercise_id = collection_exercise_controller.get_collection_exercise(survey_id, period)['id']
-    while True:
+    attempt = 1
+    while attempt <= 20:
+        logger.info("Getting iac code for collection exercise",
+                    collection_exercise_id=collection_exercise_id,
+                    social=social,
+                    attempt=attempt)
         iac_code = database_controller.get_iac_for_collection_exercise(collection_exercise_id, social=social)
         if iac_code:
             logger.info('Collection exercise finished executing', survey_id=survey_id, period=period)
             return iac_code
         time.sleep(3)
+        attempt += 1
+    raise Exception("Failed to get iac code for collection exercise")
 
 
 def generate_new_enrolment_code(case_id, business_id):


### PR DESCRIPTION
# Motivation and Context
response ops was not tracking the tab of origin of a conversation and was thus returning to open when a different tab was more appropriate. Also it was returning to the wrong tab. Most of the work was tested within response ops , but one scenario using the link in the flash message could not be easily tested that way so a new acceptance test was created

# What has changed
Deleted acceptance tests that replicated tests added to the response_ops repo.
Changed the tab definition to be a multi value conversation tab variable instead of bools to reflect changes in response ops. Refactored some tab selections to use a single call and be more DRY.

# How to test?
Run acceptance tests 

# Links
https://trello.com/c/mego4FuA
https://github.com/ONSdigital/response-operations-ui/compare/secure-message-return-to-tab?expand=1