### PR TITLE
removed redundant tests , and tests moved to the response ops repo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,7 @@ acceptance_tests: acceptance_sequential_tests acceptance_parallel_tests
 
 rasrm_acceptance_tests: rasrm_acceptance_sequential_tests rasrm_acceptance_parallel_tests
 
+all_acceptance_tests: acceptance_sequential_tests rasrm_acceptance_parallel_tests secure_messaging_acceptance_tests
 
 # Run sequentially targets
 acceptance_sequential_tests: setup

--- a/acceptance_tests/features/inbox_internal.feature
+++ b/acceptance_tests/features/inbox_internal.feature
@@ -9,20 +9,6 @@ Feature: Internal inbox
   Background: Internal user is already signed in
     Given the internal user is already signed in
 
-  @sm111_s01
-  @fixture.setup.data.with.unenrolled.respondent.user.and.internal.user
-  Scenario: If there are no messages the user will be informed of this.
-    Given the user has access to secure messaging
-    And the user has no messages in their inbox
-    When they navigate to the inbox messages
-    Then they are informed that there are no messages
-
-  @sm111_s02
-  @fixture.setup.data.with.enrolled.respondent.user.and.internal.user.and.new.iac.and.collection.exercise.to.live
-  Scenario: User is able to view all Inbox messages.
-    Given the user has got messages in their inbox
-    When they navigate to the inbox messages
-    Then they are able to view all received messages
 
   @sm111_s03
   @fixture.setup.data.with.enrolled.respondent.user.and.internal.user.and.new.iac.and.collection.exercise.to.live
@@ -38,13 +24,6 @@ Feature: Internal inbox
     Given the user has got '2' messages in their inbox
     When they navigate to the inbox messages
     Then they are able to view all received messages in reverse chronological order/latest first
-
-  @sm139_s01
-  @fixture.setup.with.internal.user
-  Scenario: User is able to view a list of filter options
-    Given the user has access to secure messaging
-    When they navigate to the select survey page
-    Then they are able to view a dropdown list of surveys
 
   @sm114_s01
   @fixture.setup.data.with.enrolled.respondent.user.and.internal.user.and.new.iac.and.collection.exercise.to.live
@@ -64,14 +43,6 @@ Feature: Internal inbox
     And they navigate to the inbox messages
     Then the message is no longer marked as unread
 
-  @sm127_s01
-  @fixture.setup.data.with.enrolled.respondent.user.and.internal.user.and.new.iac.and.collection.exercise.to.live
-  Scenario: User views 5 messages when 5 are there
-    Given the user has no messages in their inbox
-    And the user has got '5' messages in their inbox
-    When they navigate to the inbox messages
-    Then they are able to view '5' messages
-
   @sm127_s02
   @fixture.setup.data.with.enrolled.respondent.user.and.internal.user.and.new.iac.and.collection.exercise.to.live
   Scenario: User views 10 messages when 15 are there
@@ -80,21 +51,6 @@ Feature: Internal inbox
     When they navigate to the inbox messages
     Then they are able to view '10' messages
     And the pagination links are available
-
-  @sm123_s03
-  @fixture.setup.data.with.unenrolled.respondent.user.and.internal.user
-  Scenario: If there are no closed messages the user will be informed of this
-    Given the user has access to secure messaging
-    And the user has no messages in their inbox
-    When they navigate to closed conversations
-    Then they are informed that there are no closed conversations
-
-  @sm123_s04
-  @fixture.setup.data.with.unenrolled.respondent.user.and.internal.user
-  Scenario: Internal user can see closed tab
-    Given the user has access to secure messaging
-    When they navigate to the inbox messages
-    Then they can see the closed tab
 
   @fixture.setup.data.with.enrolled.respondent.user.and.internal.user.and.new.iac.and.collection.exercise.to.live
   Scenario: Internal User views new conversations

--- a/acceptance_tests/features/pages/sign_in_respondent.py
+++ b/acceptance_tests/features/pages/sign_in_respondent.py
@@ -1,9 +1,12 @@
 from acceptance_tests import browser
+from common.browser_utilities import wait_for_url_matches
 from config import Config
 
 
 def go_to():
-    browser.visit(Config.FRONTSTAGE_SERVICE + '/sign-in')
+    url = Config.FRONTSTAGE_SERVICE + '/sign-in'
+    browser.visit(url)
+    wait_for_url_matches(url, timeout=3, post_change_delay=0.5)
 
 
 def sign_in_alternate_respondent():

--- a/acceptance_tests/features/steps/inbox_internal.py
+++ b/acceptance_tests/features/steps/inbox_internal.py
@@ -72,11 +72,6 @@ def internal_user_views_initial_conversations(context):
     inbox_internal.go_to_using_context(context, 'initial')
 
 
-@then('they are informed that there are no closed conversations')
-def informed_of_no_closed_conversations(_):
-    assert inbox_internal.get_no_closed_conversations_text()
-
-
 @then('they are able to view all received messages')
 def test_presence_of_messages(_):
     assert len(inbox_internal.get_messages()) > 0
@@ -98,17 +93,6 @@ def test_message_order(_):
     first_message_date = datetime.strptime(messages[0].get('received').split(' ')[2], '%H:%M')
     second_message_date = datetime.strptime(messages[1].get('received').split(' ')[2], '%H:%M')
     assert first_message_date >= second_message_date
-
-
-@when('they navigate to the select survey page')
-def test_view_select_survey_page(_):
-    inbox_internal.go_to_select_survey()
-
-
-@then('they are able to view a dropdown list of surveys')
-def test_select_survey_page_view(_):
-    assert inbox_internal.get_filter_page_title()
-    assert inbox_internal.get_dropdown_list()
 
 
 @when('the user has an unread message in their inbox')
@@ -140,11 +124,6 @@ def message_is_no_longer_marked_unread_in_internal_inbox(_):
 def pagination_links_available(_):
     assert inbox_internal.get_pagination_previous_link()
     assert inbox_internal.get_pagination_next_link()
-
-
-@then('they can see the closed tab')
-def closed_tab_is_visible(_):
-    assert inbox_internal.closed_tab_present()
 
 
 @then('The To field should be the name of the internal user who sent the message')

--- a/acceptance_tests/features/steps/respondent_unlocking_account.py
+++ b/acceptance_tests/features/steps/respondent_unlocking_account.py
@@ -5,6 +5,7 @@ from acceptance_tests.features.pages import forgotten_password_respondent, repor
 from acceptance_tests.features.pages.forgotten_password_respondent import get_password_reset_url
 from acceptance_tests.features.pages.respondent_unlocking_account import get_lockout_message, locking_respondent_out, \
     respondent_password_reset_complete
+from common.browser_utilities import wait_for_url_matches
 
 
 @given('the respondent has locked themselves out of their account')
@@ -15,7 +16,9 @@ def respondent_unverified_account(context):
 @given('they click the password reset link')
 @when('they click the password reset link')
 def user_clicks_password_reset_link(context):
-    browser.visit(get_password_reset_url(context))
+    url = get_password_reset_url(context)
+    browser.visit(url)
+    wait_for_url_matches(url, timeout=3, post_change_delay=2)
 
 
 @given('the respondent enters their password incorrectly 10 times in a row')


### PR DESCRIPTION
# Motivation and Context
There was a need to filter conversations in response operations by both survey and ru at the same time . This led to several tests being added to the response operations ui , and the deletion of tests here. Also tests that where testing the same functinality in this area where deleted

# What has changed
 
Several tests deleted 

# How to test?
Validate that tests deleted make sense
 