### PR TITLE
bugfix on password_reset_sent, workaround on user_creates_another_col…

### DIFF
--- a/acceptance_tests/features/pages/forgotten_password_respondent.py
+++ b/acceptance_tests/features/pages/forgotten_password_respondent.py
@@ -20,7 +20,7 @@ def send_reset_link():
 
 
 def password_reset_sent():
-    return browser.find_by_text('Password reset request sent')
+    return browser.find_by_text('Check your email')
 
 
 def check_email_error_message():

--- a/acceptance_tests/features/steps/create_collection_exercise.py
+++ b/acceptance_tests/features/steps/create_collection_exercise.py
@@ -37,8 +37,8 @@ def user_creates_a_collection_exercise(context):
 
 @when('they have created the CE')
 def user_creates_another_collection_exercise(_):
-    create_collection_exercise.edit_period('202002')
-    create_collection_exercise.edit_user_description('1 February 2020')
+    create_collection_exercise.edit_period('202003')
+    create_collection_exercise.edit_user_description('1 March 2020')
     create_collection_exercise.click_save()
 
 
@@ -63,7 +63,7 @@ def check_new_collection_exercise_exists(context):
 @then('the CE must be associated to the specific survey')
 def check_new_collection_exercise_is_associated_to_the_survey(context):
     collection_exercise.click_collection_exercise_created_banner()
-    assert f'{context.survey_ref} {context.short_name} 202002 | Surveys | Survey Data Collection' in browser.title
+    assert f'{context.survey_ref} {context.short_name} 202003 | Surveys | Survey Data Collection' in browser.title
 
 
 @then('they are asked to use different details')


### PR DESCRIPTION
…lection_exercise

# Motivation and Context
From ticket “Fix acceptance tests”, change was needed to fix bugs during acceptance testing to prevent continual failure of tests on unchanged code and data.

# What has changed
Fixed wrong page string check in password_reset_sent(), and added a workaround for the odd duplicate period failure for February in user_creates_another_collection_exercise(_). 

# How to test?
make acceptance_tests

# Links
https://trello.com/c/9FIFx6cf/1631-fix-acceptance-tests
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
